### PR TITLE
Skip user presence check directly after boot

### DIFF
--- a/src/ctap1.rs
+++ b/src/ctap1.rs
@@ -186,9 +186,11 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
                 };
             }
             ControlByte::EnforceUserPresenceAndSign => {
-                self.up
-                    .user_present(&mut self.trussed, constants::U2F_UP_TIMEOUT)
-                    .map_err(|_| Error::ConditionsOfUseNotSatisfied)?;
+                if !self.skip_up_check() {
+                    self.up
+                        .user_present(&mut self.trussed, constants::U2F_UP_TIMEOUT)
+                        .map_err(|_| Error::ConditionsOfUseNotSatisfied)?;
+                }
                 0x01
             }
             ControlByte::DontEnforceUserPresenceAndSign => 0x00,

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -932,9 +932,11 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
 
         // 7. collect user presence
         let up_performed = if do_up {
-            info_now!("asking for up");
-            self.up
-                .user_present(&mut self.trussed, constants::FIDO2_UP_TIMEOUT)?;
+            if !self.skip_up_check() {
+                info_now!("asking for up");
+                self.up
+                    .user_present(&mut self.trussed, constants::FIDO2_UP_TIMEOUT)?;
+            }
             true
         } else {
             info_now!("not asking for up");


### PR DESCRIPTION
This patch adds a configuration option to skip the additional user
presence check for the first Get Assertion or Authenticate request
within a certain duration after boot.  In this case, the device
insertion is interpreted as a user presence indicator.