### PR TITLE
Return error if credential ID is too long

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -252,7 +252,8 @@ impl Credential {
         let nonce: [u8; 12] = self.nonce.as_slice().try_into().unwrap();
         let encrypted_serialized_credential = EncryptedSerializedCredential(syscall!(trussed
             .encrypt_chacha8poly1305(key_encryption_key, message, associated_data, Some(&nonce))));
-        let credential_id: CredentialId = encrypted_serialized_credential.try_into().unwrap();
+        let credential_id: CredentialId = encrypted_serialized_credential.try_into()
+            .map_err(|_| Error::RequestTooLarge)?;
 
         Ok(credential_id)
     }


### PR DESCRIPTION
Instead of panicking, we now return a RequestTooLarge error if the
encrypted and serialized credential ID is longer than 255 bytes.

Fixes: https://github.com/solokeys/fido-authenticator/issues/15