### PR TITLE
Bump trussed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ ctap-types = "0.1.0"
 delog = "0.1.0"
 heapless = "0.7"
 interchange = "0.2.0"
-littlefs2 = "0.3.1"
 serde = { version = "1.0", default-features = false }
 serde_cbor = { version = "0.11.0", default-features = false }
 serde-indexed = "0.1.0"
@@ -44,3 +43,6 @@ rand = "0.8.4"
 
 [package.metadata.docs.rs]
 features = ["dispatch"]
+
+[patch.crates-io]
+trussed = { git = "https://github.com/trussed-dev/trussed", rev = "55ea391367fce4bf5093ff2d3c79041d7aef0485" }

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -7,12 +7,10 @@ use ctap_types::{
     sizes, Error,
 };
 
-use littlefs2::path::Path;
-
 use trussed::{
     syscall, try_syscall,
     types::{
-        KeyId, KeySerialization, Location, Mechanism, MediumData, Message, PathBuf,
+        KeyId, KeySerialization, Location, Mechanism, MediumData, Message, Path, PathBuf,
         SignatureSerialization,
     },
 };

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -4,7 +4,7 @@ use core::convert::TryFrom;
 
 use trussed::{
     syscall,
-    types::{DirEntry, Location},
+    types::{DirEntry, Location, Path, PathBuf},
 };
 
 use ctap_types::{
@@ -14,8 +14,6 @@ use ctap_types::{
     webauthn::PublicKeyCredentialDescriptor,
     Error,
 };
-
-use littlefs2::path::{Path, PathBuf};
 
 use crate::{
     credential::Credential,

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,12 +12,11 @@ use ctap_types::{
 };
 use trussed::{
     client, syscall, try_syscall,
-    types::{self, KeyId, Location, Mechanism},
+    types::{self, KeyId, Location, Mechanism, PathBuf},
     Client as TrussedClient,
 };
 
 use heapless::binary_heap::{BinaryHeap, Max};
-use littlefs2::path::PathBuf;
 
 use crate::{cbor_serialize_message, credential::Credential, Result};
 


### PR DESCRIPTION
This patch bumps the Trussed dependency to include the update to littlefs2 0.4.0.