### PR TITLE
Set makeCredUvNotRqd in CTAP options

### DIFF
--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -79,6 +79,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
                 false => Some(false),
             },
             credential_mgmt_preview: Some(true),
+            make_cred_uv_not_rqd: Some(true),
             ..Default::default()
         };
         // options.rk = true;


### PR DESCRIPTION
This patch sets the makeCredUvNotRqd CTAP option to true to indicate that we support makeCredential operations without user verification. See also:
	https://fidoalliance.org/specs/fido-v2.1-rd-20201208/fido-client-to-authenticator-protocol-v2.1-rd-20201208.html#getinfo-makecreduvnotrqd

Fixes: https://github.com/Nitrokey/fido-authenticator/issues/17

Upstream PR: https://github.com/solokeys/fido-authenticator/pull/27