### PR TITLE
Reject RK option in get_assertion

### DIFF
--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -948,6 +948,11 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
 
         // 6. process any options present
 
+        // RK is not supported in get_assertion
+        if parameters.options.as_ref().and_then(|options| options.rk).is_some() {
+            return Err(Error::InvalidOption);
+        }
+
         // UP occurs by default, but option could specify not to.
         let do_up = if parameters.options.is_some() {
             parameters.options.as_ref().unwrap().up.unwrap_or(true)


### PR DESCRIPTION
The getAssertion command does not use the rk option so we return an InvalidOption error if it is set.

Fixes: https://github.com/Nitrokey/fido-authenticator/issues/23

Upstream PR: https://github.com/solokeys/fido-authenticator/pull/33