### PR TITLE
Ignore user data with empty ID in get_assertion

### DIFF
--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -1589,7 +1589,8 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
             number_of_credentials: num_credentials,
         };
 
-        if is_rk {
+        // User with empty IDs are ignored for compatibility
+        if is_rk && !credential.user.id.is_empty() {
             let mut user = credential.user.clone();
             // User identifiable information (name, DisplayName, icon) MUST not
             // be returned if user verification is not done by the authenticator.


### PR DESCRIPTION
Users with an empty ID should not be returned by getAssertion to avoid compatibility issues.

Fixes: https://github.com/Nitrokey/fido-authenticator/issues/24

Upstream PR: https://github.com/solokeys/fido-authenticator/pull/34