### PR TITLE
Allow three instead of two PIN retries per boot

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -102,7 +102,7 @@ impl State {
 
     pub fn decrement_retries<T: TrussedClient>(&mut self, trussed: &mut T) -> Result<()> {
         self.persistent.decrement_retries(trussed)?;
-        self.runtime.decrement_retries()?;
+        self.runtime.decrement_retries();
         Ok(())
     }
 
@@ -446,14 +446,9 @@ impl PersistentState {
 impl RuntimeState {
     const POWERCYCLE_RETRIES: u8 = 3;
 
-    fn decrement_retries(&mut self) -> Result<()> {
+    fn decrement_retries(&mut self) {
         if self.consecutive_pin_mismatches < Self::POWERCYCLE_RETRIES {
             self.consecutive_pin_mismatches += 1;
-        }
-        if self.consecutive_pin_mismatches == Self::POWERCYCLE_RETRIES {
-            Err(Error::PinAuthBlocked)
-        } else {
-            Ok(())
         }
     }
 


### PR DESCRIPTION
Previously, a PinAuthBlocked error was already returned after two wrong PIN entries. The reason for this as that decrement_retries also checks if the allowed retries are exceeded. This as unnecessary because pin_blocked is always checked before decrement_retries is called.

This patch removes the check in decrement_retries.

Fixes: https://github.com/Nitrokey/fido-authenticator/issues/27

Upstream PR: https://github.com/solokeys/fido-authenticator/pull/36