### PR TITLE
Update changelog and fix formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add config option for setting a maximum number of resident credentials.
 - Ignore public key credential paramters with an unknown type, as required by
   the Webauthn spec ([#28][])
+- Set the `makeCredUvNotRqd` CTAP option to `true` to indicate that we support
+  makeCredential operations without user verification ([#26][])
+- Reject `rk` option in getAssertion ([#31][])
+- Ignore user data with empty ID in getAssertion ([#32][])
+- Allow three instead of two PIN retries per boot ([#35][])
 
+[#26]: https://github.com/solokeys/fido-authenticator/issues/26
 [#28]: https://github.com/solokeys/fido-authenticator/issues/28
+[#31]: https://github.com/solokeys/fido-authenticator/issues/31
+[#32]: https://github.com/solokeys/fido-authenticator/issues/32
+[#35]: https://github.com/solokeys/fido-authenticator/issues/35
 
 ## [0.1.1] - 2022-08-22
 - Fix bug that treated U2F payloads as APDU over APDU in NFC transport @conorpp

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -947,7 +947,12 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
         // 6. process any options present
 
         // RK is not supported in get_assertion
-        if parameters.options.as_ref().and_then(|options| options.rk).is_some() {
+        if parameters
+            .options
+            .as_ref()
+            .and_then(|options| options.rk)
+            .is_some()
+        {
             return Err(Error::InvalidOption);
         }
 


### PR DESCRIPTION
This patch fixes two oversights in the recent PRs: missing changelog entries and a formatting error.