### PR TITLE
Reduce ID length for new credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject `rk` option in getAssertion ([#31][])
 - Ignore user data with empty ID in getAssertion ([#32][])
 - Allow three instead of two PIN retries per boot ([#35][])
+- Reduce ID length for new credentials ([#37][])
 
 [#26]: https://github.com/solokeys/fido-authenticator/issues/26
 [#28]: https://github.com/solokeys/fido-authenticator/issues/28
 [#31]: https://github.com/solokeys/fido-authenticator/issues/31
 [#32]: https://github.com/solokeys/fido-authenticator/issues/32
 [#35]: https://github.com/solokeys/fido-authenticator/issues/35
+[#37]: https://github.com/solokeys/fido-authenticator/issues/37
 
 ## [0.1.1] - 2022-08-22
 - Fix bug that treated U2F payloads as APDU over APDU in NFC transport @conorpp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ log-error = []
 [dev-dependencies]
 # quickcheck = "1"
 rand = "0.8.4"
+trussed = { version = "0.1", features = ["virt"] }
 
 [package.metadata.docs.rs]
 features = ["dispatch"]

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -17,7 +17,7 @@ use ctap_types::{
 
 use crate::{
     constants::MAX_RESIDENT_CREDENTIALS_GUESSTIMATE,
-    credential::Credential,
+    credential::FullCredential,
     state::{CredentialManagementEnumerateCredentials, CredentialManagementEnumerateRps},
     Authenticator, Result, TrussedRequirements, UserPresence,
 };
@@ -161,7 +161,7 @@ where
                         .read_file(Location::Internal, rk_entry.path().into(),))
                     .data;
 
-                    let credential = Credential::deserialize(&serialized)
+                    let credential = FullCredential::deserialize(&serialized)
                         // this may be a confusing error message
                         .map_err(|_| Error::InvalidCredential)?;
 
@@ -238,7 +238,7 @@ where
                         .read_file(Location::Internal, rk_entry.path().into(),))
                     .data;
 
-                    let credential = Credential::deserialize(&serialized)
+                    let credential = FullCredential::deserialize(&serialized)
                         // this may be a confusing error message
                         .map_err(|_| Error::InvalidCredential)?;
 
@@ -385,7 +385,7 @@ where
 
         let serialized = syscall!(self.trussed.read_file(Location::Internal, rk_path.into(),)).data;
 
-        let credential = Credential::deserialize(&serialized)
+        let credential = FullCredential::deserialize(&serialized)
             // this may be a confusing error message
             .map_err(|_| Error::InvalidCredential)?;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,7 +18,7 @@ use trussed::{
 
 use heapless::binary_heap::{BinaryHeap, Max};
 
-use crate::{cbor_serialize_message, credential::Credential, Result};
+use crate::{cbor_serialize_message, credential::FullCredential, Result};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CachedCredential {
@@ -479,7 +479,7 @@ impl RuntimeState {
     pub fn pop_credential<T: client::FilesystemClient>(
         &mut self,
         trussed: &mut T,
-    ) -> Option<Credential> {
+    ) -> Option<FullCredential> {
         let cached_credential = self.cached_credentials.pop()?;
 
         let credential_data = syscall!(trussed.read_file(
@@ -488,7 +488,7 @@ impl RuntimeState {
         ))
         .data;
 
-        Credential::deserialize(&credential_data).ok()
+        FullCredential::deserialize(&credential_data).ok()
     }
 
     pub fn remaining_credentials(&self) -> u32 {


### PR DESCRIPTION
This patch implements the following changes to reduce the ID length for new credentials:
- Rename the old Credential type to FullCredential and introduce a StrippedCredential type and a Credential enum to differentiate between full and reduced credential data.
- Flatten the credential data to reduce encoding overhead.
- Remove the RP id from the credential data to reduce the total length.
- Add a marker field use_short_id to FullCredential so that we don’t change the credential ID for existing RKs.

To do:
- [x] Add tests for EncryptedSerializedCredential serialized length (should be less than 255).
- [ ] Add tests for FullCredential serialized length (should fit into one littlefs block).
  - Can be done together with https://github.com/trussed-dev/fido-authenticator/issues/22.
- [ ] Investigate if we can remove more fields from StrippedCredential.
  - As we meet the size limit and the remaining fields only need one to four bytes, I think it’s not worth removing them with the risk that we might need them in the future.  We can still drop them if there is need.
- [x] Investigate what to do for CTAP1 credentials.
  - Changed to use `StrippedCredential` in `register` (`authenticate` automatically handles both by using the `Credential` enum).

Fixes: https://github.com/Nitrokey/fido-authenticator/issues/29