### PR TITLE
Update ctap types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ ctaphid-dispatch = { version = "0.1", optional = true }
 iso7816 = { version = "0.1", optional = true }
 
 [features]
-default = []
 dispatch = ["apdu-dispatch", "ctaphid-dispatch", "iso7816"]
 disable-reset-time-window = []
 enable-fido-pre = []
@@ -45,6 +44,6 @@ rand = "0.8.4"
 features = ["dispatch"]
 
 [patch.crates-io]
-ctap-types = { git = "https://github.com/Nitrokey/ctap-types.git", tag = "v0.1.2-nitrokey.2" }
+ctap-types = { git = "https://github.com/Nitrokey/ctap-types.git", rev = "42751efdc3c717135e8f26ceaa6ce23fb57d0498" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "51e68500d7601d04f884f5e95567d14b9018a6cb" }

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -195,12 +195,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
         // 7. check pubKeyCredParams algorithm is valid + supported COSE identifier
 
         let mut algorithm: Option<SigningAlgorithm> = None;
-        for param in parameters.pub_key_cred_params.iter() {
-            // Ignore unknown key types
-            if param.key_type != "public-key" {
-                continue;
-            }
-
+        for param in parameters.pub_key_cred_params.0.iter() {
             match param.alg {
                 -7 => {
                     if algorithm.is_none() {


### PR DESCRIPTION
See https://github.com/Nitrokey/ctap-types/pull/10

Note that this still fails to register to support.nitrokey.com, but now it fails with a 500 Internal error from the server.