### PR TITLE
Use references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ ctaphid-dispatch = { version = "0.1", optional = true }
 iso7816 = { version = "0.1", optional = true }
 
 [features]
-default = []
 dispatch = ["apdu-dispatch", "ctaphid-dispatch", "iso7816"]
 disable-reset-time-window = []
 enable-fido-pre = []
@@ -45,6 +44,6 @@ rand = "0.8.4"
 features = ["dispatch"]
 
 [patch.crates-io]
-ctap-types = { git = "https://github.com/Nitrokey/ctap-types.git", tag = "v0.1.2-nitrokey.2" }
+ctap-types = { git = "https://github.com/Nitrokey/ctap-types.git", rev = "42751efdc3c717135e8f26ceaa6ce23fb57d0498" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "51e68500d7601d04f884f5e95567d14b9018a6cb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ rand = "0.8.4"
 features = ["dispatch"]
 
 [patch.crates-io]
-ctap-types = { git = "https://github.com/Nitrokey/ctap-types.git", rev = "42751efdc3c717135e8f26ceaa6ce23fb57d0498" }
+ctap-types = { git = "https://github.com/nitrokey/ctap-types.git", rev = "0011b36d2a97779e77ff6f154b08008c9608f904" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "51e68500d7601d04f884f5e95567d14b9018a6cb" }
+serde-indexed = { git = "https://github.com/sosthene-nitrokey/serde-indexed.git", rev = "5005d23cb4ee8622e62188ea0f9466146f851f0d" }

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -8,7 +8,7 @@ pub(crate) use ctap_types::{
     // authenticator::{ctap1, ctap2, Error, Request, Response},
     ctap2::credential_management::CredentialProtectionPolicy,
     sizes::*,
-    webauthn::PublicKeyCredentialDescriptor,
+    webauthn::{PublicKeyCredentialDescriptor, PublicKeyCredentialDescriptorRef},
     Bytes,
     String,
 };
@@ -276,7 +276,7 @@ impl Credential {
     pub fn try_from<UP: UserPresence, T: client::Client + client::Chacha8Poly1305>(
         authnr: &mut Authenticator<UP, T>,
         rp_id_hash: &Bytes<32>,
-        descriptor: &PublicKeyCredentialDescriptor,
+        descriptor: &PublicKeyCredentialDescriptorRef,
     ) -> Result<Self> {
         Self::try_from_bytes(authnr, rp_id_hash, &descriptor.id)
     }

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -195,12 +195,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
         // 7. check pubKeyCredParams algorithm is valid + supported COSE identifier
 
         let mut algorithm: Option<SigningAlgorithm> = None;
-        for param in parameters.pub_key_cred_params.iter() {
-            // Ignore unknown key types
-            if param.key_type != "public-key" {
-                continue;
-            }
-
+        for param in parameters.pub_key_cred_params.0.iter() {
             match param.alg {
                 -7 => {
                     if algorithm.is_none() {

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -1289,7 +1289,7 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
     fn pin_prechecks(
         &mut self,
         options: &Option<ctap2::AuthenticatorOptions>,
-        pin_auth: &Option<ctap2::PinAuth>,
+        pin_auth: &Option<&ctap2::PinAuth>,
         pin_protocol: &Option<u32>,
         data: &[u8],
     ) -> Result<bool> {


### PR DESCRIPTION
This PR uses the updated ctap-types crate that uses references rather than heapless buffers to reduce the total stack usage. See https://github.com/Nitrokey/ctap-types/pull/11