### PR TITLE
Add `usbip` example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ description = "FIDO authenticator Trussed app"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[example]]
+name = "usbip"
+required-features = ["trussed/virt", "dispatch"]
+
 [dependencies]
 ctap-types = { version = "0.1.0", features = ["large-blobs"] }
 delog = "0.1.0"
@@ -41,9 +45,12 @@ log-warn = []
 log-error = []
 
 [dev-dependencies]
+env_logger = "0.11.0"
 # quickcheck = "1"
 rand = "0.8.4"
 trussed = { version = "0.1", features = ["virt"] }
+trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
+usbd-ctaphid = "0.1.0"
 
 [package.metadata.docs.rs]
 features = ["dispatch"]
@@ -55,3 +62,5 @@ apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev 
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "b1781805a2e33615d2d00b8bec80c0b1f5870ca1" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging", rev = "3b9594d93f89a5e760fe78fa5a96f125dfdcd470" }
 serde-indexed = { git = "https://github.com/sosthene-nitrokey/serde-indexed.git", rev = "5005d23cb4ee8622e62188ea0f9466146f851f0d" }
+trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.1" }
+usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid.git", tag = "v0.1.0-nitrokey.2" }

--- a/examples/usbip.rs
+++ b/examples/usbip.rs
@@ -1,0 +1,68 @@
+// Copyright (C) 2022 Nitrokey GmbH
+// SPDX-License-Identifier: CC0-1.0
+
+//! USB/IP runner for opcard.
+//! Run with cargo run --example usbip --features trussed/virt,dispatch
+
+use trussed::backend::{BackendId, CoreOnly};
+use trussed::types::Location;
+use trussed::virt::{self, Client, Ram, UserInterface};
+use trussed::{ClientImplementation, Platform};
+use trussed_usbip::ClientBuilder;
+
+const MANUFACTURER: &str = "Nitrokey";
+const PRODUCT: &str = "Nitrokey 3";
+const VID: u16 = 0x20a0;
+const PID: u16 = 0x42b2;
+
+type VirtClient = ClientImplementation<trussed_usbip::Service<Ram, CoreOnly>, CoreOnly>;
+
+struct FidoApp {
+    fido: fido_authenticator::Authenticator<fido_authenticator::Conforming, VirtClient>,
+}
+
+impl trussed_usbip::Apps<'static, VirtClient, CoreOnly> for FidoApp {
+    type Data = ();
+    fn new<B: ClientBuilder<VirtClient, CoreOnly>>(builder: &B, _data: ()) -> Self {
+        let large_blogs = Some(fido_authenticator::LargeBlobsConfig {
+            location: Location::External,
+            #[cfg(feature = "chunked")]
+            max_size: 4096,
+        });
+
+        FidoApp {
+            fido: fido_authenticator::Authenticator::new(
+                builder.build("fido", &[BackendId::Core]),
+                fido_authenticator::Conforming {},
+                fido_authenticator::Config {
+                    max_msg_size: usbd_ctaphid::constants::MESSAGE_SIZE,
+                    skip_up_timeout: None,
+                    max_resident_credential_count: Some(10),
+                    large_blobs: large_blogs,
+                },
+            ),
+        }
+    }
+
+    fn with_ctaphid_apps<T>(
+        &mut self,
+        f: impl FnOnce(&mut [&mut dyn ctaphid_dispatch::app::App<'static>]) -> T,
+    ) -> T {
+        f(&mut [&mut self.fido])
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    let options = trussed_usbip::Options {
+        manufacturer: Some(MANUFACTURER.to_owned()),
+        product: Some(PRODUCT.to_owned()),
+        serial_number: Some("TEST".into()),
+        vid: VID,
+        pid: PID,
+    };
+    trussed_usbip::Builder::new(virt::Ram::default(), options)
+        .build::<FidoApp>()
+        .exec(|_platform| {});
+}


### PR DESCRIPTION
This makes it faster to test with usbip than using the nitrokey-3-firmware usbip runner.