### PR TITLE
Pin hash space opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Implement PIN token permissions ([#63][])
 - Implement UpdateUserInformation subcommand for CredentialManagement
 - Support CTAP 2.1
+- Serialize PIN hash with `serde-bytes` ([#52][])
 
 [#26]: https://github.com/solokeys/fido-authenticator/issues/26
 [#28]: https://github.com/solokeys/fido-authenticator/issues/28
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/Nitrokey/fido-authenticator/pull/61
 [#62]: https://github.com/Nitrokey/fido-authenticator/pull/62
 [#63]: https://github.com/Nitrokey/fido-authenticator/pull/63
+[#52]: https://github.com/Nitrokey/fido-authenticator/issues/52
 
 ## [0.1.1] - 2022-08-22
 - Fix bug that treated U2F payloads as APDU over APDU in NFC transport @conorpp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ x509-parser = "0.16.0"
 features = ["dispatch"]
 
 [patch.crates-io]
+cbor-smol = { git = "https://github.com/sosthene-nitrokey/cbor-smol.git", rev = "94ee8c28edf9248b402aa4335c1dee157995197b"}
 ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "72eb68b61e3f14957c5ab89bd22f776ac860eb62" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "915fc237103fcecc29d0f0b73391f19abf6576de" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ apdu-dispatch = { version = "0.1", optional = true }
 ctaphid-dispatch = { version = "0.1", optional = true }
 iso7816 = { version = "0.1.2", optional = true }
 
+cbor-smol = { version = "0.4.0", features = ["bytes-from-array"] }
+
 [features]
 dispatch = ["apdu-dispatch", "ctaphid-dispatch", "iso7816"]
 disable-reset-time-window = []
@@ -72,7 +74,7 @@ x509-parser = "0.16.0"
 features = ["dispatch"]
 
 [patch.crates-io]
-cbor-smol = { git = "https://github.com/sosthene-nitrokey/cbor-smol.git", rev = "94ee8c28edf9248b402aa4335c1dee157995197b"}
+cbor-smol = { git = "https://github.com/sosthene-nitrokey/cbor-smol.git", rev = "9a77dc9b528b08f531d76b44af2f5336c4ef17e0"}
 ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "72eb68b61e3f14957c5ab89bd22f776ac860eb62" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "915fc237103fcecc29d0f0b73391f19abf6576de" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,3 +29,4 @@ trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "b548d379d
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
 trussed-hkdf = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "hkdf-v0.2.0" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.0" }
+cbor-smol = { git = "https://github.com/sosthene-nitrokey/cbor-smol.git", rev = "9a77dc9b528b08f531d76b44af2f5336c4ef17e0"}

--- a/src/state.rs
+++ b/src/state.rs
@@ -261,6 +261,7 @@ pub struct PersistentState {
     key_encryption_key: Option<KeyId>,
     key_wrapping_key: Option<KeyId>,
     consecutive_pin_mismatches: u8,
+    #[serde(with = "serde_bytes")]
     pin_hash: Option<[u8; 16]>,
     // Ideally, we'd dogfood a "Monotonic Counter" from trussed.
     // TODO: Add per-key counters for resident keys.
@@ -513,5 +514,25 @@ impl RuntimeState {
         }
         // to speed up future operations, we already generate the key agreement key
         self.pin_protocol = Some(PinProtocolState::new(trussed));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    #[test]
+    fn deser() {
+        let _state: PersistentState = trussed::cbor_deserialize(&hex!(
+            "
+            a5726b65795f656e6372797074696f6e5f6b657950b19a5a2845e5ec71e3
+            2a1b890892376c706b65795f7772617070696e675f6b6579f6781a636f6e
+            73656375746976655f70696e5f6d69736d617463686573006870696e5f68
+            6173689018ef1879187c1881181818f0182d18fb186418960718dd185d18
+            3f188c18766974696d657374616d7009
+        "
+        ))
+        .unwrap();
     }
 }


### PR DESCRIPTION
Reduce the storage space used by the hash of the PIN by using serde-byte-array. Fix #49 

Needs https://github.com/nickray/cbor-smol/pull/7 to properly deserialize credentials that were serialize prior to this PR such as the one in the test.