### PR TITLE
Reduce space taken by credentials, using a migration step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update dependencies:
   - Replace `trussed` dependency with `trussed-core`
   - Replace `ctaphid-dispatch` dependeny with `ctaphid-app`
+- Remove the per-relying party directory to save space ([#55][])
 
 [#26]: https://github.com/solokeys/fido-authenticator/issues/26
 [#28]: https://github.com/solokeys/fido-authenticator/issues/28
@@ -44,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#63]: https://github.com/Nitrokey/fido-authenticator/pull/63
 [#52]: https://github.com/Nitrokey/fido-authenticator/issues/52
 [#59]: https://github.com/Nitrokey/fido-authenticator/issues/59
+[#55]: https://github.com/Nitrokey/fido-authenticator/issues/55
 
 ## [0.1.1] - 2022-08-22
 - Fix bug that treated U2F payloads as APDU over APDU in NFC transport @conorpp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ log-warn = []
 log-error = []
 
 [dev-dependencies]
+admin-app = { version = "0.1.0", features = ["migration-tests"] }
 aes = "0.8.4"
 cbc = { version = "0.1.2", features = ["alloc"] }
 ciborium = { version = "0.2.2" }
@@ -83,6 +84,7 @@ x509-parser = "0.16.0"
 features = ["dispatch"]
 
 [patch.crates-io]
+admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.19" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "6bba8fde36d05c0227769eb63345744e87d84b2b" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "1e1ca03a3a62ea9b802f4070ea4bce002eeb4bec" }
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "4fe4e4e287dac1d92fcd4f97e8926497bfa9d7a9" }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,6 +2,10 @@
 //!
 //! Needs cleanup.
 
+pub mod migrate;
+
+use core::num::NonZeroU32;
+
 use ctap_types::{
     ctap2::AttestationFormatsPreference,
     // 2022-02-27: 10 credentials
@@ -200,14 +204,13 @@ impl Identity {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CredentialManagementEnumerateRps {
-    pub remaining: u32,
+    pub remaining: NonZeroU32,
     pub rp_id_hash: [u8; 32],
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CredentialManagementEnumerateCredentials {
     pub remaining: u32,
-    pub rp_dir: PathBuf,
     pub prev_filename: PathBuf,
 }
 
@@ -251,7 +254,7 @@ pub struct RuntimeState {
 // Currently, this causes the entire authnr to reset state. Maybe it should even reformat disk
 //
 // - An alternative would be `heapless::Map`, but I'd prefer something more typed.
-#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize, Default)]
 pub struct PersistentState {
     #[serde(skip)]
     // TODO: there has to be a better way than.. this
@@ -288,15 +291,15 @@ impl PersistentState {
 
         let data = result.unwrap().data;
 
-        let result = cbor_smol::cbor_deserialize(&data);
-
-        if result.is_err() {
-            info!("err deser'ing: {:?}", result.err().unwrap());
+        let state: Self = cbor_smol::cbor_deserialize(&data).map_err(|_err| {
+            info!("err deser'ing: {_err:?}",);
             info!("{}", hex_str!(&data));
-            return Err(Error::Other);
-        }
+            Error::Other
+        })?;
 
-        result.map_err(|_| Error::Other)
+        debug!("Loaded state: {state:#?}");
+
+        Ok(state)
     }
 
     pub fn save<T: FilesystemClient>(&self, trussed: &mut T) -> Result<()> {

--- a/src/state/migrate.rs
+++ b/src/state/migrate.rs
@@ -1,0 +1,267 @@
+use littlefs2_core::{path, DirEntry, DynFilesystem, Error, Path, PathBuf};
+
+fn ignore_does_not_exists(error: Error) -> Result<(), Error> {
+    if matches!(error, Error::NO_SUCH_ENTRY) {
+        return Ok(());
+    }
+    Err(error)
+}
+
+/// Migration function, to be used with trussed-staging's `migrate` management syscall
+///
+/// `base_path` must be the base of the file directory of the fido app (often `/fido/dat`)
+pub fn migrate_no_rp_dir(fs: &dyn DynFilesystem, base_path: &Path) -> Result<(), Error> {
+    let rk_dir = base_path.join(path!("rk"));
+
+    fs.read_dir_and_then(&rk_dir, &mut |dir| migrate_rk_dir(fs, &rk_dir, dir))
+        .or_else(ignore_does_not_exists)
+}
+
+fn migrate_rk_dir(
+    fs: &dyn DynFilesystem,
+    rk_dir: &Path,
+    dir: &mut dyn Iterator<Item = Result<DirEntry, Error>>,
+) -> Result<(), Error> {
+    for rp in dir.skip(2) {
+        let rp = rp?;
+        if rp.metadata().is_file() {
+            continue;
+        }
+
+        migrate_rp_dir(fs, rk_dir, rp.path())?;
+    }
+    Ok(())
+}
+
+fn migrate_rp_dir(fs: &dyn DynFilesystem, rk_dir: &Path, rp_path: &Path) -> Result<(), Error> {
+    let rp_id_hex = rp_path.file_name().unwrap().as_str();
+    debug_assert_eq!(rp_id_hex.len(), 16);
+
+    fs.read_dir_and_then(rp_path, &mut |rp_dir| {
+        for file in rp_dir.skip(2) {
+            let file = file?;
+            let cred_id_hex = file.file_name().as_str();
+            let mut buf = [0; 33];
+            buf[0..16].copy_from_slice(rp_id_hex.as_bytes());
+            buf[16] = b'.';
+            buf[17..].copy_from_slice(cred_id_hex.as_bytes());
+            fs.rename(
+                file.path(),
+                &rk_dir.join(&PathBuf::try_from(buf.as_slice()).unwrap()),
+            )?;
+        }
+        Ok(())
+    })?;
+
+    fs.remove_dir(rp_path)?;
+
+    Ok(())
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use admin_app::migrations::test_utils::{test_migration_one, FsValues};
+
+    use super::*;
+
+    const FIDO_DAT_DIR_BEFORE: FsValues = FsValues::Dir(&[
+        (path!("persistent-state.cbor"), FsValues::File(137)),
+        (
+            path!("rk"),
+            FsValues::Dir(&[(
+                path!("74a6ea9213c99c2f"),
+                FsValues::Dir(&[
+                    (path!("038dfc6165b78be9"), FsValues::File(128)),
+                    (path!("1ecbbfbed8992287"), FsValues::File(122)),
+                    (path!("7c24db95312eac56"), FsValues::File(122)),
+                    (path!("978cba44dfe39871"), FsValues::File(155)),
+                    (path!("ac889a0433749726"), FsValues::File(138)),
+                ]),
+            )]),
+        ),
+    ]);
+
+    const FIDO_DAT_DIR_AFTER: FsValues = FsValues::Dir(&[
+        (path!("persistent-state.cbor"), FsValues::File(137)),
+        (
+            path!("rk"),
+            FsValues::Dir(&[
+                (
+                    path!("74a6ea9213c99c2f.038dfc6165b78be9"),
+                    FsValues::File(128),
+                ),
+                (
+                    path!("74a6ea9213c99c2f.1ecbbfbed8992287"),
+                    FsValues::File(122),
+                ),
+                (
+                    path!("74a6ea9213c99c2f.7c24db95312eac56"),
+                    FsValues::File(122),
+                ),
+                (
+                    path!("74a6ea9213c99c2f.978cba44dfe39871"),
+                    FsValues::File(155),
+                ),
+                (
+                    path!("74a6ea9213c99c2f.ac889a0433749726"),
+                    FsValues::File(138),
+                ),
+            ]),
+        ),
+    ]);
+
+    const FIDO_SEC_DIR: FsValues = FsValues::Dir(&[
+        (
+            path!("069386c3c735689061ac51b8bca9f160"),
+            FsValues::File(48),
+        ),
+        (
+            path!("233d86bfc2f196ff7c108cf23a282bd5"),
+            FsValues::File(36),
+        ),
+        (
+            path!("2bdef14a0e18d28191162f8c1599d598"),
+            FsValues::File(36),
+        ),
+        (
+            path!("3efe6394c20aa8128e27b376e226a58b"),
+            FsValues::File(36),
+        ),
+        (
+            path!("4711aa79b4834ef8e551f80e523ba8d2"),
+            FsValues::File(36),
+        ),
+        (
+            path!("b43bf8b7897087b7195b8ac53dcb5f11"),
+            FsValues::File(36),
+        ),
+    ]);
+
+    #[test]
+    fn migration_no_auth() {
+        const TEST_VALUES_BEFORE: FsValues = FsValues::Dir(&[
+            (
+                path!("fido"),
+                FsValues::Dir(&[
+                    (path!("dat"), FIDO_DAT_DIR_BEFORE),
+                    (path!("sec"), FIDO_SEC_DIR),
+                ]),
+            ),
+            (
+                path!("trussed"),
+                FsValues::Dir(&[(
+                    path!("dat"),
+                    FsValues::Dir(&[(path!("rng-state.bin"), FsValues::File(32))]),
+                )]),
+            ),
+        ]);
+
+        const TEST_VALUES_AFTER: FsValues = FsValues::Dir(&[
+            (
+                path!("fido"),
+                FsValues::Dir(&[
+                    (path!("dat"), FIDO_DAT_DIR_AFTER),
+                    (path!("sec"), FIDO_SEC_DIR),
+                ]),
+            ),
+            (
+                path!("trussed"),
+                FsValues::Dir(&[(
+                    path!("dat"),
+                    FsValues::Dir(&[(path!("rng-state.bin"), FsValues::File(32))]),
+                )]),
+            ),
+        ]);
+
+        test_migration_one(&TEST_VALUES_BEFORE, &TEST_VALUES_AFTER, |fs| {
+            migrate_no_rp_dir(fs, path!("fido/dat"))
+        });
+    }
+
+    #[test]
+    fn migration_auth() {
+        const AUTH_SECRETS_DIR: (&Path, FsValues) = (
+            path!("secrets"),
+            FsValues::Dir(&[(
+                path!("backend-auth"),
+                FsValues::Dir(&[(
+                    path!("dat"),
+                    FsValues::Dir(&[
+                        (path!("application_salt"), FsValues::File(16)),
+                        (path!("pin.00"), FsValues::File(118)),
+                    ]),
+                )]),
+            )]),
+        );
+
+        const BACKEND_DIR: (&Path, FsValues) = (
+            path!("backend-auth"),
+            FsValues::Dir(&[(
+                path!("dat"),
+                FsValues::Dir(&[(path!("salt"), FsValues::File(16))]),
+            )]),
+        );
+
+        const TRUSSED_DIR: (&Path, FsValues) = (
+            path!("trussed"),
+            FsValues::Dir(&[(
+                path!("dat"),
+                FsValues::Dir(&[(path!("rng-state.bin"), FsValues::File(32))]),
+            )]),
+        );
+
+        const TEST_BEFORE: FsValues = FsValues::Dir(&[
+            BACKEND_DIR,
+            (
+                path!("fido"),
+                FsValues::Dir(&[
+                    (path!("dat"), FIDO_DAT_DIR_BEFORE),
+                    (path!("sec"), FIDO_SEC_DIR),
+                ]),
+            ),
+            AUTH_SECRETS_DIR,
+            TRUSSED_DIR,
+        ]);
+
+        const TEST_AFTER: FsValues = FsValues::Dir(&[
+            BACKEND_DIR,
+            (
+                path!("fido"),
+                FsValues::Dir(&[
+                    (path!("dat"), FIDO_DAT_DIR_AFTER),
+                    (path!("sec"), FIDO_SEC_DIR),
+                ]),
+            ),
+            AUTH_SECRETS_DIR,
+            TRUSSED_DIR,
+        ]);
+
+        test_migration_one(&TEST_BEFORE, &TEST_AFTER, |fs| {
+            migrate_no_rp_dir(fs, path!("fido/dat"))
+        });
+    }
+
+    #[test]
+    fn migration_empty() {
+        const TEST_VALUES: FsValues = FsValues::Dir(&[
+            (
+                path!("fido"),
+                FsValues::Dir(&[
+                    (path!("dat"), FsValues::Dir(&[])),
+                    (path!("sec"), FIDO_SEC_DIR),
+                ]),
+            ),
+            (
+                path!("trussed"),
+                FsValues::Dir(&[(
+                    path!("dat"),
+                    FsValues::Dir(&[(path!("rng-state.bin"), FsValues::File(32))]),
+                )]),
+            ),
+        ]);
+        test_migration_one(&TEST_VALUES, &TEST_VALUES, |fs| {
+            migrate_no_rp_dir(fs, path!("fido/dat"))
+        });
+    }
+}

--- a/tests/fs/mod.rs
+++ b/tests/fs/mod.rs
@@ -31,13 +31,7 @@ impl Entries {
     }
 
     pub fn try_remove_rks(&mut self) -> usize {
-        let n = self.0.len();
-        self.0.retain(|path, _| {
-            let (start, _) = path.rsplit_once('/').unwrap();
-            let start = start.rsplit_once('/').map(|(start, _)| start);
-            start != Some("fido/dat/rk")
-        });
-        n - self.0.len()
+        self.try_remove_dir("fido/dat/rk")
     }
 
     pub fn try_remove_dir(&mut self, dir: &str) -> usize {


### PR DESCRIPTION
For now the migration step renames the files, testing need to be done to make sure that this will not fail when only one block remains free.