### PR TITLE
Use serde-indexed to optimize the size of resident credentials

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ serde_cbor = { version = "0.11.0", features = ["std"] }
 trussed = { version = "0.1", features = ["virt"] }
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
 usbd-ctaphid = "0.1.0"
+hex-literal = "0.4.1"
 
 [package.metadata.docs.rs]
 features = ["dispatch"]
@@ -61,7 +62,8 @@ features = ["dispatch"]
 ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "7d4ad69e64ad308944c012aef5b9cfd7654d9be8" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "915fc237103fcecc29d0f0b73391f19abf6576de" }
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "b1781805a2e33615d2d00b8bec80c0b1f5870ca1" }
+trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey.17" }
+littlefs2 = { git = "https://github.com/trussed-dev/littlefs2", rev = "ebd27e49ca321089d01d8c9b169c4aeb58ceeeca" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging", rev = "3b9594d93f89a5e760fe78fa5a96f125dfdcd470" }
 serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ log-error = []
 env_logger = "0.11.0"
 # quickcheck = "1"
 rand = "0.8.4"
+serde_test = "1.0.176"
+serde_cbor = { version = "0.11.0", features = ["std"] }
 trussed = { version = "0.1", features = ["virt"] }
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
 usbd-ctaphid = "0.1.0"
@@ -61,6 +63,7 @@ ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git"
 apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "915fc237103fcecc29d0f0b73391f19abf6576de" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "b1781805a2e33615d2d00b8bec80c0b1f5870ca1" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging", rev = "3b9594d93f89a5e760fe78fa5a96f125dfdcd470" }
-serde-indexed = { git = "https://github.com/sosthene-nitrokey/serde-indexed.git", rev = "5005d23cb4ee8622e62188ea0f9466146f851f0d" }
+serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.1" }
 usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid.git", tag = "v0.1.0-nitrokey.2" }
+cbor-smol = { git = "https://github.com/sosthene-nitrokey/cbor-smol.git", rev = "327f723d53263d4ac1da368660de4fe4aa8ebef8" }

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -290,9 +290,9 @@ impl From<LocalPublicKeyCredentialUserEntity>
 )]
 pub struct CredentialData {
     // id, name, url
-    pub rp: ctap_types::webauthn::PublicKeyCredentialRpEntity,
+    pub rp: LocalPublicKeyCredentialRpEntity,
     // id, icon, name, display_name
-    pub user: ctap_types::webauthn::PublicKeyCredentialUserEntity,
+    pub user: LocalPublicKeyCredentialUserEntity,
 
     // can be just a counter, need to be able to determine "latest"
     pub creation_time: u32,
@@ -422,8 +422,8 @@ impl FullCredential {
     ) -> Self {
         info!("credential for algorithm {}", algorithm);
         let data = CredentialData {
-            rp: rp.clone(),
-            user: user.clone(),
+            rp: rp.clone().into(),
+            user: user.clone().into(),
 
             creation_time: timestamp,
             use_counter: true,
@@ -508,7 +508,6 @@ impl FullCredential {
         let data = &mut stripped.data;
 
         data.rp.name = None;
-        data.rp.icon = None;
 
         data.user.icon = None;
         data.user.name = None;
@@ -583,7 +582,6 @@ impl From<&FullCredential> for StrippedCredential {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ctap_types::webauthn::{PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity};
     use trussed::{
         client::{Chacha8Poly1305, Sha256},
         types::Location,
@@ -591,12 +589,11 @@ mod test {
 
     fn credential_data() -> CredentialData {
         CredentialData {
-            rp: PublicKeyCredentialRpEntity {
+            rp: LocalPublicKeyCredentialRpEntity {
                 id: String::from("John Doe"),
                 name: None,
-                icon: None,
             },
-            user: PublicKeyCredentialUserEntity {
+            user: LocalPublicKeyCredentialUserEntity {
                 id: Bytes::from_slice(&[1, 2, 3]).unwrap(),
                 icon: None,
                 name: None,
@@ -670,12 +667,11 @@ mod test {
 
     fn random_credential_data() -> CredentialData {
         CredentialData {
-            rp: PublicKeyCredentialRpEntity {
+            rp: LocalPublicKeyCredentialRpEntity {
                 id: random_string(),
                 name: maybe_random_string(),
-                icon: None,
             },
-            user: PublicKeyCredentialUserEntity {
+            user: LocalPublicKeyCredentialUserEntity {
                 id: random_bytes(), //Bytes::from_slice(&[1,2,3]).unwrap(),
                 icon: maybe_random_string(),
                 name: maybe_random_string(),
@@ -1014,6 +1010,46 @@ mod test {
                 Token::Bytes(b"Testing user id"),
                 Token::MapEnd,
             ],
+        );
+    }
+
+    // Test credentials that were serialized before the migration to serde_indexed for serialization
+    #[test]
+    fn legacy_full_credential() {
+        use hex_literal::hex;
+        let data = hex!(
+            "
+            a3000201a700a16269646b776562617574686e2e696f01a2626964476447
+            567a644445646e616d65657465737431020003f504260582005037635754
+            c9882b21565a9f8a47b0ece408f5024cf62ca01ed181a3d03d561fc7
+        "
+        );
+
+        let credential = FullCredential::deserialize(&Bytes::from_slice(&data).unwrap()).unwrap();
+        assert!(matches!(credential.ctap, CtapVersion::Fido21Pre));
+        assert_eq!(credential.nonce, &hex!("F62CA01ED181A3D03D561FC7"));
+        assert_eq!(
+            credential.data,
+            CredentialData {
+                rp: LocalPublicKeyCredentialRpEntity {
+                    id: "webauthn.io".try_into().unwrap(),
+                    name: None,
+                },
+                user: LocalPublicKeyCredentialUserEntity {
+                    id: Bytes::from_slice(&hex!("6447567A644445")).unwrap(),
+                    icon: None,
+                    name: Some("test1".try_into().unwrap()),
+                    display_name: None,
+                },
+                creation_time: 0,
+                use_counter: true,
+                algorithm: -7,
+                key: Key::ResidentKey(KeyId::from_value(0x37635754C9882B21565A9F8A47B0ECE4)),
+                hmac_secret: None,
+                cred_protect: None,
+                use_short_id: Some(true),
+                large_blob_key: None,
+            },
         );
     }
 

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -1664,7 +1664,7 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
                         user.name = None;
                         user.display_name = None;
                     }
-                    response.user = Some(user);
+                    response.user = Some(user.into());
                 }
             }
 

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -168,7 +168,7 @@ where
                     let rp = credential.data.rp;
 
                     response.rp_id_hash = Some(self.hash(rp.id.as_ref()));
-                    response.rp = Some(rp);
+                    response.rp = Some(rp.into());
                 }
             }
 
@@ -245,7 +245,7 @@ where
                     let rp = credential.data.rp;
 
                     response.rp_id_hash = Some(self.hash(rp.id.as_ref()));
-                    response.rp = Some(rp);
+                    response.rp = Some(rp.into());
 
                     // cache state for next call
                     if remaining > 1 {
@@ -449,7 +449,7 @@ where
         };
 
         let response = Response {
-            user: Some(credential.data.user),
+            user: Some(credential.data.user.into()),
             credential_id: Some(credential_id.into()),
             public_key: Some(cose_public_key),
             cred_protect,


### PR DESCRIPTION
Requires https://github.com/nickray/cbor-smol/pull/8

Thankfully serde's default deserialization support both deserializing with fields as integers, and deserializing with fields as str. So there is no need for manual deserialization code.