### PR TITLE
Serialize credential with fields names using only 1 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement UpdateUserInformation subcommand for CredentialManagement
 - Support CTAP 2.1
 - Serialize PIN hash with `serde-bytes` ([#52][])
+- Reduce the space taken by credential serializaiton ([#59][])
 
 [#26]: https://github.com/solokeys/fido-authenticator/issues/26
 [#28]: https://github.com/solokeys/fido-authenticator/issues/28
@@ -39,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#62]: https://github.com/Nitrokey/fido-authenticator/pull/62
 [#63]: https://github.com/Nitrokey/fido-authenticator/pull/63
 [#52]: https://github.com/Nitrokey/fido-authenticator/issues/52
+[#59]: https://github.com/Nitrokey/fido-authenticator/issues/59
 
 ## [0.1.1] - 2022-08-22
 - Fix bug that treated U2F payloads as APDU over APDU in NFC transport @conorpp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ log = "0.4.21"
 p256 = { version = "0.13.2", features = ["ecdh"] }
 rand = "0.8.4"
 sha2 = "0.10"
+serde_test = "1.0.176"
 trussed = { version = "0.1", features = ["virt"] }
 trussed-staging = { version = "0.3.0", features = ["chunked", "hkdf", "virt"] }
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -1753,7 +1753,7 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
                         user.name = None;
                         user.display_name = None;
                     }
-                    response.user = Some(user);
+                    response.user = Some(user.into());
                 }
             }
 

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -167,7 +167,7 @@ where
                     let rp = credential.data.rp;
 
                     response.rp_id_hash = Some(ByteArray::new(self.hash(rp.id.as_ref())));
-                    response.rp = Some(rp);
+                    response.rp = Some(rp.into());
                 }
             }
 
@@ -244,7 +244,7 @@ where
                     let rp = credential.data.rp;
 
                     response.rp_id_hash = Some(ByteArray::new(self.hash(rp.id.as_ref())));
-                    response.rp = Some(rp);
+                    response.rp = Some(rp.into());
 
                     // cache state for next call
                     if remaining > 1 {
@@ -448,7 +448,7 @@ where
         };
 
         let mut response = Response::default();
-        response.user = Some(credential.data.user);
+        response.user = Some(credential.data.user.into());
         response.credential_id = Some(credential_id.into());
         response.public_key = Some(cose_public_key);
         response.cred_protect = cred_protect;


### PR DESCRIPTION
This saves space when serializing credentials.

We cannot use [`#[serde(remote)]`](https://serde.rs/remote-derive.html) because that would require supporting `#[serde(with)]` in `serde_indexed`, already used for `CredentialData`

This replaces #58 it should be 1 bytes larger per serialized fields, but is better than serde-indexed as it has les risks to break accidentally when adding/removing a field.