### PR TITLE
Fix error type for third invalid PIN entry

### DIFF
--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -1185,12 +1185,7 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
             self.state
                 .runtime
                 .rotate_key_agreement_key(&mut self.trussed);
-            if self.state.persistent.retries() == 0 {
-                return Err(Error::PinBlocked);
-            }
-            if self.state.persistent.pin_blocked() {
-                return Err(Error::PinAuthBlocked);
-            }
+            self.state.pin_blocked()?;
             return Err(Error::PinInvalid);
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -402,7 +402,7 @@ impl PersistentState {
     }
 
     pub fn retries(&self) -> u8 {
-        Self::RESET_RETRIES - self.consecutive_pin_mismatches
+        Self::RESET_RETRIES.saturating_sub(self.consecutive_pin_mismatches)
     }
 
     pub fn pin_blocked(&self) -> bool {


### PR DESCRIPTION
If the user provides a wrong PIN and the persistent or per-boot PIN retry counter reaches its limit, we have to return the PinBlocked (persistent) or PinAuthBlocked (per boot) error code instead of PinInvalid.  The previous implementation checked the persistent retry counter twice instead of checking both counters.

This patch fixes this problem by using the combined State::pin_blocked method instead of manually checking the persistent and runtime state directly.

It also replaces a raw subtraction when computing the remaining retries with a saturating sub, just to be sure.