### PR TITLE
Fix error type for cancelled user presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce ID length for new credentials ([#37][])
 - Update apdu-dispatch and reject calls to `select` ([#40][])
 - Implement the `largeBlobKey` extension and the `largeBlobs` command ([#38][])
+- Fix error type for third invalid PIN entry ([#60][])
+- Fix error type for cancelled user presence ([#61][])
 
 [#26]: https://github.com/solokeys/fido-authenticator/issues/26
 [#28]: https://github.com/solokeys/fido-authenticator/issues/28
@@ -25,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#37]: https://github.com/solokeys/fido-authenticator/issues/37
 [#40]: https://github.com/nitrokey/fido-authenticator/pull/40
 [#38]: https://github.com/Nitrokey/fido-authenticator/issues/38
+[#60]: https://github.com/Nitrokey/fido-authenticator/pull/60
+[#61]: https://github.com/Nitrokey/fido-authenticator/pull/61
 
 ## [0.1.1] - 2022-08-22
 - Fix bug that treated U2F payloads as APDU over APDU in NFC transport @conorpp

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ impl UserPresence for Conforming {
         let result = syscall!(trussed.confirm_user_present(timeout_milliseconds)).result;
         result.map_err(|err| match err {
             trussed::types::consent::Error::TimedOut => Error::UserActionTimeout,
-            // trussed::types::consent::Error::TimedOut => Error::KeepaliveCancel,
+            trussed::types::consent::Error::Interrupted => Error::KeepaliveCancel,
             _ => Error::OperationDenied,
         })
     }


### PR DESCRIPTION
This patch changes the error type that is returned if a user presence check is cancelled using the CTAPHID_CANCEL command from OPERATION_DENIED to KEEPALIVE_CANCEL.