### PR TITLE
Optimize key and PIN token generation

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -513,5 +513,7 @@ impl RuntimeState {
         if let Some(pin_protocol) = self.pin_protocol.take() {
             pin_protocol.reset(trussed);
         }
+        // to speed up future operations, we already generate the key agreement key
+        self.pin_protocol = Some(PinProtocolState::new(trussed));
     }
 }


### PR DESCRIPTION
This patch generates the key agreement key directly after the reset to improve the execution time of the next requests.  It also refactors the PIN token generation and storage so that the PIN token is only generated when needed, and only for the PIN protocol that is currently in use.