### PR TITLE
Use trussed-chunked instead of trussed-staging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde-indexed = "0.1.0"
 sha2 = { version = "0.10", default-features = false }
 trussed = "0.1"
 trussed-hkdf = { version = "0.1.0" }
-trussed-staging = { version = "0.1.0", default-features = false, optional = true }
+trussed-chunked = { version = "0.1.0", optional = true }
 
 apdu-dispatch = { version = "0.1", optional = true }
 ctaphid-dispatch = { version = "0.1", optional = true }
@@ -35,7 +35,7 @@ dispatch = ["apdu-dispatch", "ctaphid-dispatch", "iso7816"]
 disable-reset-time-window = []
 
 # enables support for a large-blob array longer than 1024 bytes
-chunked = ["trussed-staging/chunked"]
+chunked = ["trussed-chunked"]
 
 log-all = []
 log-none = []
@@ -62,7 +62,7 @@ apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev 
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "ebd27e49ca321089d01d8c9b169c4aeb58ceeeca" }
 serde-indexed = { git = "https://github.com/sosthene-nitrokey/serde-indexed.git", rev = "5005d23cb4ee8622e62188ea0f9466146f851f0d" }
 trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey.18" }
+trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
 trussed-hkdf = { git = "https://github.com/Nitrokey/trussed-hkdf-backend.git", tag = "v0.1.0" }
-trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging", tag = "v0.1.0-nitrokey-hmac256p256.3" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.1" }
 usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid.git", tag = "v0.1.0-nitrokey.2" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,10 +81,10 @@ pub trait ExtensionRequirements {}
 impl<T> ExtensionRequirements for T {}
 
 #[cfg(feature = "chunked")]
-pub trait ExtensionRequirements: trussed_staging::streaming::ChunkedClient {}
+pub trait ExtensionRequirements: trussed_chunked::ChunkedClient {}
 
 #[cfg(feature = "chunked")]
-impl<T> ExtensionRequirements for T where T: trussed_staging::streaming::ChunkedClient {}
+impl<T> ExtensionRequirements for T where T: trussed_chunked::ChunkedClient {}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 /// Externally defined configuration.


### PR DESCRIPTION
This patch adapts to the extraction of the extensions from trussed-staging, see:
        https://github.com/trussed-dev/trussed-staging/pull/19