### PR TITLE
Extend test suite with basic credential management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,17 +44,22 @@ log-warn = []
 log-error = []
 
 [dev-dependencies]
+aes = "0.8.4"
+cbc = { version = "0.1.2", features = ["alloc"] }
 ciborium = { version = "0.2.2" }
+cipher = "0.4.4"
 ctaphid = { version = "0.3.1", default-features = false }
 delog = { version = "0.1.6", features = ["std-log"] }
 env_logger = "0.11.0"
+hmac = "0.12.1"
 interchange = "0.3.0"
 log = "0.4.21"
-# quickcheck = "1"
+p256 = { version = "0.13.2", features = ["ecdh"] }
 rand = "0.8.4"
+sha2 = "0.10"
 trussed = { version = "0.1", features = ["virt"] }
-trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
 trussed-staging = { version = "0.3.0", features = ["chunked", "hkdf", "virt"] }
+trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
 usbd-ctaphid = "0.1.0"
 
 [package.metadata.docs.rs]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeMap;
 use ciborium::Value;
 use ctap_types::ctap2::Operation;
 
+use virt::Ctap2Error;
 use webauthn::{MakeCredentialRequest, PubKeyCredParam, Rp, User};
 
 #[test]
@@ -20,7 +21,7 @@ fn test_ping() {
 #[test]
 fn test_get_info() {
     virt::run_ctap2(|device| {
-        let reply: BTreeMap<u8, Value> = device.call(Operation::GetInfo, &Value::Null);
+        let reply: BTreeMap<u8, Value> = device.call(Operation::GetInfo, &Value::Null).unwrap();
         let versions: Vec<String> = reply.get(&1).unwrap().deserialized().unwrap();
         assert!(versions.contains(&"FIDO_2_0".to_owned()));
         assert!(versions.contains(&"FIDO_2_1".to_owned()));
@@ -36,9 +37,25 @@ fn test_make_credential() {
             .display_name("John Doe");
         let pub_key_cred_params = vec![PubKeyCredParam::new("public-key", -7)];
         let request = MakeCredentialRequest::new(b"", rp, user, pub_key_cred_params);
-        let reply: BTreeMap<u8, Value> = device.call(Operation::MakeCredential, &request.into());
+        let reply: BTreeMap<u8, Value> = device
+            .call(Operation::MakeCredential, &request.into())
+            .unwrap();
         assert_eq!(reply.get(&1).unwrap(), &Value::from("packed"));
         assert!(reply.contains_key(&2));
         assert!(reply.contains_key(&3));
+    });
+}
+
+#[test]
+fn test_make_credential_invalid_params() {
+    virt::run_ctap2(|device| {
+        let rp = Rp::new("example.com");
+        let user = User::new(b"id123")
+            .name("john.doe")
+            .display_name("John Doe");
+        let pub_key_cred_params = vec![PubKeyCredParam::new("public-key", -11)];
+        let request = MakeCredentialRequest::new(b"", rp, user, pub_key_cred_params);
+        let result = device.call::<Value>(Operation::MakeCredential, &request.into());
+        assert_eq!(result, Err(Ctap2Error(0x26)));
     });
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -3,13 +3,8 @@
 mod virt;
 mod webauthn;
 
-use std::collections::BTreeMap;
-
-use ciborium::Value;
-use ctap_types::ctap2::Operation;
-
 use virt::Ctap2Error;
-use webauthn::{MakeCredentialRequest, PubKeyCredParam, Rp, User};
+use webauthn::{GetInfo, MakeCredential, PubKeyCredParam, Rp, User};
 
 #[test]
 fn test_ping() {
@@ -21,10 +16,9 @@ fn test_ping() {
 #[test]
 fn test_get_info() {
     virt::run_ctap2(|device| {
-        let reply: BTreeMap<u8, Value> = device.call(Operation::GetInfo, &Value::Null).unwrap();
-        let versions: Vec<String> = reply.get(&1).unwrap().deserialized().unwrap();
-        assert!(versions.contains(&"FIDO_2_0".to_owned()));
-        assert!(versions.contains(&"FIDO_2_1".to_owned()));
+        let reply = device.exec(GetInfo).unwrap();
+        assert!(reply.versions.contains(&"FIDO_2_0".to_owned()));
+        assert!(reply.versions.contains(&"FIDO_2_1".to_owned()));
     });
 }
 
@@ -36,13 +30,11 @@ fn test_make_credential() {
             .name("john.doe")
             .display_name("John Doe");
         let pub_key_cred_params = vec![PubKeyCredParam::new("public-key", -7)];
-        let request = MakeCredentialRequest::new(b"", rp, user, pub_key_cred_params);
-        let reply: BTreeMap<u8, Value> = device
-            .call(Operation::MakeCredential, &request.into())
-            .unwrap();
-        assert_eq!(reply.get(&1).unwrap(), &Value::from("packed"));
-        assert!(reply.contains_key(&2));
-        assert!(reply.contains_key(&3));
+        let request = MakeCredential::new(b"", rp, user, pub_key_cred_params);
+        let reply = device.exec(request).unwrap();
+        assert_eq!(reply.fmt, "packed");
+        assert!(reply.auth_data.is_bytes());
+        assert!(reply.att_stmt.is_map());
     });
 }
 
@@ -54,8 +46,8 @@ fn test_make_credential_invalid_params() {
             .name("john.doe")
             .display_name("John Doe");
         let pub_key_cred_params = vec![PubKeyCredParam::new("public-key", -11)];
-        let request = MakeCredentialRequest::new(b"", rp, user, pub_key_cred_params);
-        let result = device.call::<Value>(Operation::MakeCredential, &request.into());
+        let request = MakeCredential::new(b"", rp, user, pub_key_cred_params);
+        let result = device.exec(request);
         assert_eq!(result, Err(Ctap2Error(0x26)));
     });
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -3,8 +3,16 @@
 mod virt;
 mod webauthn;
 
-use virt::Ctap2Error;
-use webauthn::{GetInfo, MakeCredential, PubKeyCredParam, Rp, User};
+use std::collections::BTreeMap;
+
+use ciborium::Value;
+
+use virt::{Ctap2, Ctap2Error};
+use webauthn::{
+    ClientPin, CredentialManagement, CredentialManagementParams, GetInfo, KeyAgreementKey,
+    MakeCredential, MakeCredentialOptions, PinToken, PubKeyCredParam, PublicKey, Rp, SharedSecret,
+    User,
+};
 
 #[test]
 fn test_ping() {
@@ -19,7 +27,75 @@ fn test_get_info() {
         let reply = device.exec(GetInfo).unwrap();
         assert!(reply.versions.contains(&"FIDO_2_0".to_owned()));
         assert!(reply.versions.contains(&"FIDO_2_1".to_owned()));
+        assert_eq!(reply.pin_protocols, Some(vec![2, 1]));
     });
+}
+
+fn get_shared_secret(device: &Ctap2, platform_key_agreement: &KeyAgreementKey) -> SharedSecret {
+    let reply = device.exec(ClientPin::new(2, 2)).unwrap();
+    let authenticator_key_agreement: PublicKey = reply.key_agreement.unwrap().into();
+    platform_key_agreement.shared_secret(&authenticator_key_agreement)
+}
+
+fn set_pin(
+    device: &Ctap2,
+    key_agreement_key: &KeyAgreementKey,
+    shared_secret: &SharedSecret,
+    pin: &[u8],
+) {
+    let mut padded_pin = [0; 64];
+    padded_pin[..pin.len()].copy_from_slice(pin);
+    let pin_enc = shared_secret.encrypt(&padded_pin);
+    let pin_auth = shared_secret.authenticate(&pin_enc);
+    let mut request = ClientPin::new(2, 3);
+    request.key_agreement = Some(key_agreement_key.public_key());
+    request.new_pin_enc = Some(pin_enc);
+    request.pin_auth = Some(pin_auth);
+    device.exec(request).unwrap();
+}
+
+#[test]
+fn test_set_pin() {
+    let key_agreement_key = KeyAgreementKey::generate();
+    virt::run_ctap2(|device| {
+        let shared_secret = get_shared_secret(&device, &key_agreement_key);
+        set_pin(&device, &key_agreement_key, &shared_secret, b"123456");
+    })
+}
+
+fn get_pin_token(
+    device: &Ctap2,
+    key_agreement_key: &KeyAgreementKey,
+    shared_secret: &SharedSecret,
+    pin: &[u8],
+    permissions: u8,
+    rp_id: Option<String>,
+) -> PinToken {
+    use sha2::{Digest as _, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(pin);
+    let pin_hash = hasher.finalize();
+    let pin_hash_enc = shared_secret.encrypt(&pin_hash[..16]);
+    let mut request = ClientPin::new(2, 9);
+    request.key_agreement = Some(key_agreement_key.public_key());
+    request.pin_hash_enc = Some(pin_hash_enc);
+    request.permissions = Some(permissions);
+    request.rp_id = rp_id;
+    let reply = device.exec(request).unwrap();
+    let encrypted_pin_token = reply.pin_token.as_ref().unwrap().as_bytes().unwrap();
+    shared_secret.decrypt_pin_token(encrypted_pin_token)
+}
+
+#[test]
+fn test_get_pin_token() {
+    let key_agreement_key = KeyAgreementKey::generate();
+    let pin = b"123456";
+    virt::run_ctap2(|device| {
+        let shared_secret = get_shared_secret(&device, &key_agreement_key);
+        set_pin(&device, &key_agreement_key, &shared_secret, pin);
+        get_pin_token(&device, &key_agreement_key, &shared_secret, pin, 0x01, None);
+    })
 }
 
 #[test]
@@ -50,4 +126,111 @@ fn test_make_credential_invalid_params() {
         let result = device.exec(request);
         assert_eq!(result, Err(Ctap2Error(0x26)));
     });
+}
+
+#[derive(Debug)]
+struct TestListCredentials {
+    pin_token_rp_id: bool,
+}
+
+impl TestListCredentials {
+    fn run(&self) {
+        let key_agreement_key = KeyAgreementKey::generate();
+        let pin = b"123456";
+        let rp_id = "example.com";
+        let user_id = b"id123";
+        virt::run_ctap2(|device| {
+            let shared_secret = get_shared_secret(&device, &key_agreement_key);
+            set_pin(&device, &key_agreement_key, &shared_secret, pin);
+
+            let pin_token =
+                get_pin_token(&device, &key_agreement_key, &shared_secret, pin, 0x01, None);
+            // TODO: client data
+            let client_data_hash = b"";
+            let pin_auth = pin_token.authenticate(client_data_hash);
+
+            let rp = Rp::new(rp_id);
+            let user = User::new(user_id).name("john.doe").display_name("John Doe");
+            let pub_key_cred_params = vec![PubKeyCredParam::new("public-key", -7)];
+            let mut request = MakeCredential::new(client_data_hash, rp, user, pub_key_cred_params);
+            request.options = Some(MakeCredentialOptions::default().rk(true));
+            request.pin_auth = Some(pin_auth);
+            request.pin_protocol = Some(2);
+            let reply = device.exec(request).unwrap();
+            let auth_data = reply.auth_data.as_bytes().unwrap();
+            assert!(auth_data.len() >= 37, "{}", auth_data.len());
+            assert_eq!(
+                auth_data[32] & 0b1,
+                0b1,
+                "up flag not set in auth_data: 0b{:b}",
+                auth_data[32]
+            );
+            assert_eq!(
+                auth_data[32] & 0b100,
+                0b100,
+                "uv flag not set in auth_data: 0b{:b}",
+                auth_data[32]
+            );
+
+            let pin_token =
+                get_pin_token(&device, &key_agreement_key, &shared_secret, pin, 0x04, None);
+            let pin_auth = pin_token.authenticate(&[0x02]);
+            let request = CredentialManagement {
+                subcommand: 0x02,
+                subcommand_params: None,
+                pin_protocol: 2,
+                pin_auth,
+            };
+            let reply = device.exec(request).unwrap();
+            let rp: BTreeMap<String, Value> = reply.rp.unwrap().deserialized().unwrap();
+            // TODO: check rp ID hash
+            assert!(reply.rp_id_hash.is_some());
+            assert_eq!(reply.total_rps, Some(1));
+            assert_eq!(rp.get("id").unwrap(), &Value::from(rp_id));
+
+            let pin_token_rp_id = self.pin_token_rp_id.then(|| rp_id.to_owned());
+            let pin_token = get_pin_token(
+                &device,
+                &key_agreement_key,
+                &shared_secret,
+                pin,
+                0x04,
+                pin_token_rp_id,
+            );
+            let params = CredentialManagementParams {
+                rp_id_hash: reply.rp_id_hash.unwrap().as_bytes().unwrap().to_owned(),
+            };
+            let mut pin_auth_param = vec![0x04];
+            pin_auth_param.extend_from_slice(&params.serialized());
+            let pin_auth = pin_token.authenticate(&pin_auth_param);
+            let request = CredentialManagement {
+                subcommand: 0x04,
+                subcommand_params: Some(params),
+                pin_protocol: 2,
+                pin_auth,
+            };
+            let reply = device.exec(request).unwrap();
+            let user: BTreeMap<String, Value> = reply.user.unwrap().deserialized().unwrap();
+            assert_eq!(reply.total_credentials, Some(1));
+            assert_eq!(user.get("id").unwrap(), &Value::from(user_id.as_slice()));
+        });
+    }
+}
+
+#[test]
+fn test_list_credentials() {
+    for pin_token_rp_id in [false, true] {
+        // true is omitted because it currently fails, see:
+        // https://github.com/Nitrokey/fido-authenticator/issues/80
+        if pin_token_rp_id {
+            continue;
+        }
+
+        let test = TestListCredentials { pin_token_rp_id };
+        println!("{}", "=".repeat(80));
+        println!("Running test:");
+        println!("{test:#?}");
+        println!();
+        test.run();
+    }
 }

--- a/tests/virt/mod.rs
+++ b/tests/virt/mod.rs
@@ -114,7 +114,11 @@ impl Ctap2<'_> {
                 }
                 err => panic!("failed to execute CTAP2 command: {err:?}"),
             })?;
-        let value: Value = ciborium::from_reader(reply.as_slice()).unwrap();
+        let value: Value = if reply.is_empty() {
+            Value::Map(Vec::new())
+        } else {
+            ciborium::from_reader(reply.as_slice()).unwrap()
+        };
         log::debug!("Received reply {value:?}");
         Ok(value.into())
     }

--- a/tests/virt/pipe.rs
+++ b/tests/virt/pipe.rs
@@ -93,10 +93,10 @@ enum State {
     Sending((Response, MessageState)),
 }
 
-pub struct Pipe {
+pub struct Pipe<'a> {
     queue: VecDeque<[u8; PACKET_SIZE]>,
     state: State,
-    interchange: Requester<'static>,
+    interchange: Requester<'a>,
     buffer: [u8; MESSAGE_SIZE],
     last_channel: u32,
     implements: u8,
@@ -106,8 +106,8 @@ pub struct Pipe {
     version: Version,
 }
 
-impl Pipe {
-    pub fn new(interchange: Requester<'static>) -> Self {
+impl<'a> Pipe<'a> {
+    pub fn new(interchange: Requester<'a>) -> Self {
         Self {
             queue: Default::default(),
             state: State::Idle,

--- a/tests/webauthn/mod.rs
+++ b/tests/webauthn/mod.rs
@@ -1,6 +1,110 @@
 use std::collections::BTreeMap;
 
 use ciborium::Value;
+use cipher::{BlockDecryptMut as _, BlockEncryptMut as _, KeyIvInit};
+use hmac::Mac;
+use rand::RngCore as _;
+
+pub struct KeyAgreementKey(p256::ecdh::EphemeralSecret);
+
+impl KeyAgreementKey {
+    pub fn generate() -> Self {
+        Self(p256::ecdh::EphemeralSecret::random(&mut rand::thread_rng()))
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey(self.0.public_key())
+    }
+
+    pub fn shared_secret(&self, peer: &PublicKey) -> SharedSecret {
+        let shared_point = self.0.diffie_hellman(&peer.0);
+        let hkdf = shared_point.extract::<sha2::Sha256>(Some(&[0; 32]));
+        let mut hmac_key = [0; 32];
+        let mut aes_key = [0; 32];
+        hkdf.expand(b"CTAP2 HMAC key", &mut hmac_key).unwrap();
+        hkdf.expand(b"CTAP2 AES key", &mut aes_key).unwrap();
+        SharedSecret { hmac_key, aes_key }
+    }
+}
+
+pub struct PublicKey(p256::PublicKey);
+
+impl From<PublicKey> for Value {
+    fn from(public_key: PublicKey) -> Value {
+        let encoded = p256::EncodedPoint::from(&public_key.0);
+        let mut map = Map::default();
+        map.push(1, 2);
+        map.push(3, -25);
+        map.push(-1, 1);
+        map.push(-2, encoded.x().unwrap().as_slice());
+        map.push(-3, encoded.y().unwrap().as_slice());
+        map.into()
+    }
+}
+
+impl From<Value> for PublicKey {
+    fn from(value: Value) -> Self {
+        let map: BTreeMap<i8, Value> = value.deserialized().unwrap();
+        let kty = map.get(&1).unwrap();
+        let alg = map.get(&3).unwrap();
+        let crv = map.get(&-1).unwrap();
+        let x = map.get(&-2).unwrap().as_bytes().unwrap().as_slice();
+        let y = map.get(&-3).unwrap().as_bytes().unwrap().as_slice();
+
+        assert_eq!(kty, &Value::from(2));
+        assert_eq!(alg, &Value::from(-25));
+        assert_eq!(crv, &Value::from(1));
+        let encoded = p256::EncodedPoint::from_affine_coordinates(x.into(), y.into(), false);
+        Self(encoded.try_into().unwrap())
+    }
+}
+
+pub struct SharedSecret {
+    hmac_key: [u8; 32],
+    aes_key: [u8; 32],
+}
+
+impl SharedSecret {
+    pub fn encrypt(&self, data: &[u8]) -> Vec<u8> {
+        let mut iv = [0; 16];
+        rand::thread_rng().fill_bytes(&mut iv);
+
+        let cipher: cbc::Encryptor<aes::Aes256> =
+            KeyIvInit::new(self.aes_key.as_ref().into(), iv.as_ref().into());
+        let encrypted = cipher.encrypt_padded_vec_mut::<cipher::block_padding::NoPadding>(data);
+
+        let mut result = Vec::new();
+        result.extend_from_slice(&iv);
+        result.extend_from_slice(&encrypted);
+        result
+    }
+
+    pub fn decrypt_pin_token(&self, data: &[u8]) -> PinToken {
+        let (iv, data) = data.split_first_chunk::<16>().unwrap();
+        let cipher: cbc::Decryptor<aes::Aes256> =
+            KeyIvInit::new(self.aes_key.as_ref().into(), iv.into());
+        let pin_token = cipher
+            .decrypt_padded_vec_mut::<cipher::block_padding::NoPadding>(data)
+            .unwrap();
+        PinToken(pin_token.try_into().unwrap())
+    }
+
+    pub fn authenticate(&self, data: &[u8]) -> [u8; 32] {
+        let mut mac: hmac::Hmac<sha2::Sha256> = Mac::new_from_slice(&self.hmac_key).unwrap();
+        mac.update(data);
+        mac.finalize().into_bytes().into()
+    }
+}
+
+pub struct PinToken([u8; 32]);
+
+impl PinToken {
+    pub fn authenticate(&self, data: &[u8]) -> [u8; 32] {
+        let mut mac: hmac::Hmac<sha2::Sha256> = Mac::new_from_slice(&self.0).unwrap();
+        mac.update(data);
+        mac.finalize().into_bytes().into()
+    }
+}
 
 #[derive(Default)]
 pub struct Map(Vec<(Value, Value)>);
@@ -21,6 +125,80 @@ pub trait Request: Into<Value> {
     const COMMAND: u8;
 
     type Reply: From<Value>;
+}
+
+pub struct ClientPin {
+    protocol: u8,
+    subcommand: u8,
+    pub key_agreement: Option<PublicKey>,
+    pub pin_auth: Option<[u8; 32]>,
+    pub new_pin_enc: Option<Vec<u8>>,
+    pub pin_hash_enc: Option<Vec<u8>>,
+    pub permissions: Option<u8>,
+    pub rp_id: Option<String>,
+}
+
+impl ClientPin {
+    pub fn new(protocol: u8, subcommand: u8) -> Self {
+        Self {
+            protocol,
+            subcommand,
+            key_agreement: None,
+            new_pin_enc: None,
+            pin_hash_enc: None,
+            permissions: None,
+            pin_auth: None,
+            rp_id: None,
+        }
+    }
+}
+
+impl From<ClientPin> for Value {
+    fn from(request: ClientPin) -> Self {
+        let mut map = Map::default();
+        map.push(1, request.protocol);
+        map.push(2, request.subcommand);
+        if let Some(key_agreement) = request.key_agreement {
+            map.push(3, key_agreement);
+        }
+        if let Some(pin_auth) = request.pin_auth {
+            map.push(4, pin_auth.as_slice());
+        }
+        if let Some(new_pin_enc) = request.new_pin_enc {
+            map.push(5, new_pin_enc);
+        }
+        if let Some(pin_hash_enc) = request.pin_hash_enc {
+            map.push(6, pin_hash_enc);
+        }
+        if let Some(permissions) = request.permissions {
+            map.push(9, permissions);
+        }
+        if let Some(rp_id) = request.rp_id {
+            map.push(0x0a, rp_id);
+        }
+        map.into()
+    }
+}
+
+impl Request for ClientPin {
+    const COMMAND: u8 = 0x06;
+
+    type Reply = ClientPinReply;
+}
+
+pub struct ClientPinReply {
+    pub key_agreement: Option<Value>,
+    pub pin_token: Option<Value>,
+}
+
+impl From<Value> for ClientPinReply {
+    fn from(value: Value) -> Self {
+        let mut map: BTreeMap<u8, Value> = value.deserialized().unwrap();
+        Self {
+            key_agreement: map.remove(&1),
+            pin_token: map.remove(&2),
+        }
+    }
 }
 
 pub struct Rp {
@@ -121,6 +299,9 @@ pub struct MakeCredential {
     rp: Rp,
     user: User,
     pub_key_cred_params: Vec<PubKeyCredParam>,
+    pub options: Option<MakeCredentialOptions>,
+    pub pin_auth: Option<[u8; 32]>,
+    pub pin_protocol: Option<u8>,
 }
 
 impl MakeCredential {
@@ -135,6 +316,9 @@ impl MakeCredential {
             rp,
             user,
             pub_key_cred_params: pub_key_cred_params.into(),
+            options: None,
+            pin_auth: None,
+            pin_protocol: None,
         }
     }
 }
@@ -153,6 +337,55 @@ impl From<MakeCredential> for Value {
                 .map(Value::from)
                 .collect::<Vec<_>>(),
         );
+        if let Some(options) = request.options {
+            map.push(7, options);
+        }
+        if let Some(pin_auth) = request.pin_auth {
+            map.push(8, pin_auth.as_slice());
+        }
+        if let Some(pin_protocol) = request.pin_protocol {
+            map.push(9, pin_protocol);
+        }
+        map.into()
+    }
+}
+
+#[derive(Default)]
+pub struct MakeCredentialOptions {
+    rk: Option<bool>,
+    up: Option<bool>,
+    uv: Option<bool>,
+}
+
+impl MakeCredentialOptions {
+    pub fn rk(mut self, rk: bool) -> Self {
+        self.rk = Some(rk);
+        self
+    }
+
+    pub fn up(mut self, up: bool) -> Self {
+        self.up = Some(up);
+        self
+    }
+
+    pub fn uv(mut self, uv: bool) -> Self {
+        self.uv = Some(uv);
+        self
+    }
+}
+
+impl From<MakeCredentialOptions> for Value {
+    fn from(options: MakeCredentialOptions) -> Value {
+        let mut map = Map::default();
+        if let Some(rk) = options.rk {
+            map.push("rk", rk);
+        }
+        if let Some(up) = options.up {
+            map.push("up", up);
+        }
+        if let Some(uv) = options.uv {
+            map.push("uv", uv);
+        }
         map.into()
     }
 }
@@ -197,6 +430,7 @@ impl Request for GetInfo {
 
 pub struct GetInfoReply {
     pub versions: Vec<String>,
+    pub pin_protocols: Option<Vec<u8>>,
 }
 
 impl From<Value> for GetInfoReply {
@@ -204,6 +438,75 @@ impl From<Value> for GetInfoReply {
         let mut map: BTreeMap<u8, Value> = value.deserialized().unwrap();
         Self {
             versions: map.remove(&1).unwrap().deserialized().unwrap(),
+            pin_protocols: map.remove(&6).map(|value| value.deserialized().unwrap()),
+        }
+    }
+}
+
+pub struct CredentialManagement {
+    pub subcommand: u8,
+    pub subcommand_params: Option<CredentialManagementParams>,
+    pub pin_protocol: u8,
+    pub pin_auth: [u8; 32],
+}
+
+impl From<CredentialManagement> for Value {
+    fn from(request: CredentialManagement) -> Value {
+        let mut map = Map::default();
+        map.push(1, request.subcommand);
+        if let Some(subcommand_params) = request.subcommand_params {
+            map.push(2, subcommand_params);
+        }
+        map.push(3, request.pin_protocol);
+        map.push(4, request.pin_auth.as_slice());
+        map.into()
+    }
+}
+
+impl Request for CredentialManagement {
+    const COMMAND: u8 = 0x0A;
+
+    type Reply = CredentialManagementReply;
+}
+
+#[derive(Clone)]
+pub struct CredentialManagementParams {
+    pub rp_id_hash: Vec<u8>,
+}
+
+impl CredentialManagementParams {
+    pub fn serialized(&self) -> Vec<u8> {
+        let mut serialized = Vec::new();
+        ciborium::into_writer(&Value::from(self.clone()), &mut serialized).unwrap();
+        serialized
+    }
+}
+
+impl From<CredentialManagementParams> for Value {
+    fn from(params: CredentialManagementParams) -> Value {
+        let mut map = Map::default();
+        map.push(1, params.rp_id_hash);
+        map.into()
+    }
+}
+
+pub struct CredentialManagementReply {
+    pub rp: Option<Value>,
+    pub rp_id_hash: Option<Value>,
+    pub total_rps: Option<usize>,
+    pub user: Option<Value>,
+    pub total_credentials: Option<usize>,
+}
+
+impl From<Value> for CredentialManagementReply {
+    fn from(value: Value) -> Self {
+        let mut map: BTreeMap<u8, Value> = value.deserialized().unwrap();
+        Self {
+            rp: map.remove(&3),
+            rp_id_hash: map.remove(&4),
+            total_rps: map.remove(&5).map(|value| value.deserialized().unwrap()),
+            user: map.remove(&6),
+            total_credentials: map.remove(&9).map(|value| value.deserialized().unwrap()),
         }
     }
 }


### PR DESCRIPTION
This PR improves the infrastructure for the test suite and also adds some tests for basic credential management that reproduce https://github.com/Nitrokey/fido-authenticator/issues/80 (if enabled).

To do:
- [x] reduce boilerplate code
- [x] parametrize tests, maybe with `exhaustive`?
- [ ] randomize tests, maybe with `quickcheck`?
- [x] add negative tests
- [x] add logging
- [x] improve error formatting