### PR TITLE
Use cosey and update ctap_types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,12 @@ name = "usbip"
 required-features = ["dispatch"]
 
 [dependencies]
-ctap-types = { version = "0.1.0", features = ["large-blobs"] }
+ctap-types = { version = "0.2.0", features = ["large-blobs"] }
+cosey = "0.3"
 delog = "0.1.0"
 heapless = "0.7"
 serde = { version = "1.0", default-features = false }
+serde_bytes = { version = "0.11.14", default-features = false }
 serde-indexed = "0.1.0"
 sha2 = { version = "0.10", default-features = false }
 trussed = "0.1"
@@ -66,14 +68,12 @@ usbd-ctaphid = "0.1.0"
 features = ["dispatch"]
 
 [patch.crates-io]
-ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "4846817d9cd44604121680a19d46f3264973a3ce" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "915fc237103fcecc29d0f0b73391f19abf6576de" }
-littlefs2 = { git = "https://github.com/sosthene-nitrokey/littlefs2.git", rev = "2b45a7559ff44260c6dd693e4cb61f54ae5efc53" }
-serde-indexed = { git = "https://github.com/sosthene-nitrokey/serde-indexed.git", rev = "5005d23cb4ee8622e62188ea0f9466146f851f0d" }
+littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "2b45a7559ff44260c6dd693e4cb61f54ae5efc53" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "b548d379dcbd67d29453d94847b7bc33ae92e673" }
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
 trussed-hkdf = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "hkdf-v0.2.0" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.0" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.1" }
-usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid.git", tag = "v0.1.0-nitrokey.2" }
+usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid.git", rev = "dcff9009c3cd1ef9e5b09f8f307aca998fc9a8c8" }

--- a/src/ctap1.rs
+++ b/src/ctap1.rs
@@ -4,6 +4,7 @@ use ctap_types::{
     ctap1::{authenticate, register, Authenticator, ControlByte, Error, Result},
     heapless_bytes::Bytes,
 };
+use serde_bytes::ByteArray;
 
 use trussed::{
     syscall,
@@ -50,7 +51,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
             .serialize_p256_key(public_key, KeySerialization::EcdhEsHkdf256))
         .serialized_key;
         syscall!(self.trussed.delete(public_key));
-        let cose_key: ctap_types::cose::EcdhEsHkdf256PublicKey =
+        let cose_key: cosey::EcdhEsHkdf256PublicKey =
             trussed::cbor_deserialize(&serialized_cose_public_key).unwrap();
 
         let wrapping_key = self
@@ -74,8 +75,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
                 .to_bytes()
                 .map_err(|_| Error::UnspecifiedCheckingError)?,
         );
-        let nonce = syscall!(self.trussed.random_bytes(12)).bytes;
-        let nonce = Bytes::from_slice(&nonce).unwrap();
+        let nonce = ByteArray::new(self.nonce());
 
         let credential = StrippedCredential {
             ctap: credential::CtapVersion::U2fV2,
@@ -102,14 +102,14 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
             .key_encryption_key(&mut self.trussed)
             .map_err(|_| Error::NotEnoughMemory)?;
         let credential_id = credential
-            .id(&mut self.trussed, kek, &reg.app_id)
+            .id(&mut self.trussed, kek, reg.app_id)
             .map_err(|_| Error::NotEnoughMemory)?;
 
         let mut commitment = Commitment::new();
 
         commitment.push(0).unwrap(); // reserve byte
-        commitment.extend_from_slice(&reg.app_id).unwrap();
-        commitment.extend_from_slice(&reg.challenge).unwrap();
+        commitment.extend_from_slice(reg.app_id).unwrap();
+        commitment.extend_from_slice(reg.challenge).unwrap();
 
         commitment.extend_from_slice(&credential_id.0).unwrap();
 
@@ -144,14 +144,14 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
         Ok(register::Response::new(
             0x05,
             &cose_key,
-            &credential_id.0,
+            credential_id.0,
             signature,
-            &cert,
+            cert,
         ))
     }
 
     fn authenticate(&mut self, auth: &authenticate::Request) -> Result<authenticate::Response> {
-        let cred = Credential::try_from_bytes(self, &auth.app_id, &auth.key_handle);
+        let cred = Credential::try_from_bytes(self, auth.app_id, auth.key_handle);
 
         let user_presence_byte = match auth.control_byte {
             ControlByte::CheckOnly => {
@@ -218,12 +218,12 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
 
         let mut commitment = Commitment::new();
 
-        commitment.extend_from_slice(&auth.app_id).unwrap();
+        commitment.extend_from_slice(auth.app_id).unwrap();
         commitment.push(user_presence_byte).unwrap();
         commitment
             .extend_from_slice(&sig_count.to_be_bytes())
             .unwrap();
-        commitment.extend_from_slice(&auth.challenge).unwrap();
+        commitment.extend_from_slice(auth.challenge).unwrap();
 
         let signature = syscall!(self.trussed.sign(
             Mechanism::P256,

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -201,18 +201,20 @@ where
 }
 
 #[allow(unused)]
-fn request_operation(request: &ctap2::Request) -> ctap2::Operation {
+fn request_operation(request: &ctap2::Request) -> Option<ctap2::Operation> {
+    // TODO: move into ctap-types
     match request {
-        ctap2::Request::MakeCredential(_) => ctap2::Operation::MakeCredential,
-        ctap2::Request::GetAssertion(_) => ctap2::Operation::GetAssertion,
-        ctap2::Request::GetNextAssertion => ctap2::Operation::GetNextAssertion,
-        ctap2::Request::GetInfo => ctap2::Operation::GetInfo,
-        ctap2::Request::ClientPin(_) => ctap2::Operation::ClientPin,
-        ctap2::Request::Reset => ctap2::Operation::Reset,
-        ctap2::Request::CredentialManagement(_) => ctap2::Operation::CredentialManagement,
-        ctap2::Request::Selection => ctap2::Operation::Selection,
-        ctap2::Request::LargeBlobs(_) => ctap2::Operation::LargeBlobs,
-        ctap2::Request::Vendor(operation) => ctap2::Operation::Vendor(*operation),
+        ctap2::Request::MakeCredential(_) => Some(ctap2::Operation::MakeCredential),
+        ctap2::Request::GetAssertion(_) => Some(ctap2::Operation::GetAssertion),
+        ctap2::Request::GetNextAssertion => Some(ctap2::Operation::GetNextAssertion),
+        ctap2::Request::GetInfo => Some(ctap2::Operation::GetInfo),
+        ctap2::Request::ClientPin(_) => Some(ctap2::Operation::ClientPin),
+        ctap2::Request::Reset => Some(ctap2::Operation::Reset),
+        ctap2::Request::CredentialManagement(_) => Some(ctap2::Operation::CredentialManagement),
+        ctap2::Request::Selection => Some(ctap2::Operation::Selection),
+        ctap2::Request::LargeBlobs(_) => Some(ctap2::Operation::LargeBlobs),
+        ctap2::Request::Vendor(operation) => Some(ctap2::Operation::Vendor(*operation)),
+        _ => None,
     }
 }
 
@@ -229,5 +231,6 @@ fn response_operation(request: &ctap2::Response) -> Option<ctap2::Operation> {
         ctap2::Response::Selection => Some(ctap2::Operation::Selection),
         ctap2::Response::LargeBlobs(_) => Some(ctap2::Operation::LargeBlobs),
         ctap2::Response::Vendor => None,
+        _ => None,
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,7 +5,6 @@
 use ctap_types::{
     // 2022-02-27: 10 credentials
     sizes::MAX_CREDENTIAL_COUNT_IN_LIST, // U8 currently
-    Bytes,
     Error,
     String,
 };
@@ -23,7 +22,7 @@ use crate::{
     Result, TrussedRequirements,
 };
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CachedCredential {
     pub timestamp: u32,
     // PathBuf has length 255 + 1, we only need 36 + 1
@@ -43,7 +42,7 @@ impl Ord for CachedCredential {
     }
 }
 
-#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default)]
 pub struct CredentialCacheGeneric<const N: usize>(BinaryHeap<CachedCredential, Max, N>);
 impl<const N: usize> CredentialCacheGeneric<N> {
     pub fn push(&mut self, item: CachedCredential) {
@@ -128,7 +127,7 @@ impl State {
 }
 
 /// Batch device identity (aaguid, certificate, key).
-#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Identity {
     // can this be [u8; 16] or need Bytes for serialization?
     // aaguid: Option<Bytes<consts::U16>>,
@@ -196,22 +195,20 @@ impl Identity {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CredentialManagementEnumerateRps {
     pub remaining: u32,
-    pub rp_id_hash: Bytes<32>,
+    pub rp_id_hash: [u8; 32],
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CredentialManagementEnumerateCredentials {
     pub remaining: u32,
     pub rp_dir: PathBuf,
     pub prev_filename: PathBuf,
 }
 
-#[derive(
-    Clone, Debug, /*uDebug,*/ Default, /*PartialEq,*/ serde::Deserialize, serde::Serialize,
-)]
+#[derive(Clone, Debug, Default)]
 pub struct ActiveGetAssertionData {
     pub rp_id_hash: [u8; 32],
     pub client_data_hash: [u8; 32],


### PR DESCRIPTION
This patch replaces our duplicated COSE implementation with the `cosey` crate and updates the `ctap-types` dependency.