### PR TITLE
Implement CTAP 2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ x509-parser = "0.16.0"
 features = ["dispatch"]
 
 [patch.crates-io]
-ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "ff20dfb5049fb5e25c18d1d27049d0bc98a5be8b" }
+ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "72eb68b61e3f14957c5ab89bd22f776ac860eb62" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "915fc237103fcecc29d0f0b73391f19abf6576de" }
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "2b45a7559ff44260c6dd693e4cb61f54ae5efc53" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "usbip"
 required-features = ["dispatch"]
 
 [dependencies]
-ctap-types = { version = "0.2.0", features = ["large-blobs", "third-party-payment"] }
+ctap-types = { version = "0.2.0", features = ["get-info-full", "large-blobs", "third-party-payment"] }
 cosey = "0.3"
 delog = "0.1.0"
 heapless = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "usbip"
 required-features = ["dispatch"]
 
 [dependencies]
-ctap-types = { version = "0.2.0", features = ["large-blobs"] }
+ctap-types = { version = "0.2.0", features = ["large-blobs", "third-party-payment"] }
 cosey = "0.3"
 delog = "0.1.0"
 heapless = "0.7"
@@ -49,6 +49,7 @@ log-error = []
 aes = "0.8.4"
 cbc = { version = "0.1.2", features = ["alloc"] }
 ciborium = { version = "0.2.2" }
+ciborium-io = "0.2.2"
 cipher = "0.4.4"
 ctaphid = { version = "0.3.1", default-features = false }
 delog = { version = "0.1.6", features = ["std-log"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,7 +23,7 @@ doc = false
 bench = false
 
 [patch.crates-io]
-ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "ff20dfb5049fb5e25c18d1d27049d0bc98a5be8b" }
+ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "72eb68b61e3f14957c5ab89bd22f776ac860eb62" }
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "2b45a7559ff44260c6dd693e4cb61f54ae5efc53" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "b548d379dcbd67d29453d94847b7bc33ae92e673" }
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }

--- a/src/ctap1.rs
+++ b/src/ctap1.rs
@@ -91,6 +91,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
             hmac_secret: None,
             cred_protect: None,
             large_blob_key: None,
+            third_party_payment: None,
         };
 
         // info!("made credential {:?}", &credential);

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -85,6 +85,14 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
         }
         transports.push(Transport::Usb).unwrap();
 
+        let mut attestation_formats = Vec::new();
+        attestation_formats
+            .push(AttestationStatementFormat::Packed)
+            .unwrap();
+        attestation_formats
+            .push(AttestationStatementFormat::None)
+            .unwrap();
+
         let (_, aaguid) = self.state.identity.attestation(&mut self.trussed);
 
         let mut response = ctap2::get_info::Response::default();
@@ -98,6 +106,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
         response.pin_protocols = Some(pin_protocols);
         response.max_creds_in_list = Some(ctap_types::sizes::MAX_CREDENTIAL_COUNT_IN_LIST);
         response.max_cred_id_length = Some(ctap_types::sizes::MAX_CREDENTIAL_ID_LENGTH);
+        response.attestation_formats = Some(attestation_formats);
         response
     }
 

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -453,6 +453,8 @@ where
         response.public_key = Some(cose_public_key);
         response.cred_protect = cred_protect;
         response.large_blob_key = credential.data.large_blob_key;
+        response.third_party_payment =
+            Some(credential.data.third_party_payment.unwrap_or_default());
         Ok(response)
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,7 @@
 //! Needs cleanup.
 
 use ctap_types::{
+    ctap2::AttestationFormatsPreference,
     // 2022-02-27: 10 credentials
     sizes::MAX_CREDENTIAL_COUNT_IN_LIST, // U8 currently
     Error,
@@ -216,6 +217,7 @@ pub struct ActiveGetAssertionData {
     pub up_performed: bool,
     pub multiple_credentials: bool,
     pub extensions: Option<ctap_types::ctap2::get_assertion::ExtensionsInput>,
+    pub attestation_formats_preference: Option<AttestationFormatsPreference>,
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
- Implement the `thirdPartyPayment` extension
- Add support for attestation format preferences
- Add support for attestation in `get_assertion`
- Add extensive tests for the new features