### PR TITLE
Add dynamic estimation of remaining credential space

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_bytes = { version = "0.11.14", default-features = false }
 serde-indexed = "0.1.0"
 sha2 = { version = "0.10", default-features = false }
 trussed = "0.1"
+trussed-fs-info = "0.1.0"
 trussed-hkdf = { version = "0.2.0" }
 trussed-chunked = { version = "0.1.0", optional = true }
 
@@ -65,7 +66,7 @@ p256 = { version = "0.13.2", features = ["ecdh"] }
 rand = "0.8.4"
 sha2 = "0.10"
 trussed = { version = "0.1", features = ["virt"] }
-trussed-staging = { version = "0.3.0", features = ["chunked", "hkdf", "virt"] }
+trussed-staging = { version = "0.3.0", features = ["chunked", "hkdf", "virt", "fs-info"] }
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
 usbd-ctaphid = "0.1.0"
 x509-parser = "0.16.0"
@@ -78,10 +79,11 @@ cbor-smol = { git = "https://github.com/sosthene-nitrokey/cbor-smol.git", rev = 
 ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "72eb68b61e3f14957c5ab89bd22f776ac860eb62" }
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
 apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "915fc237103fcecc29d0f0b73391f19abf6576de" }
-littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "2b45a7559ff44260c6dd693e4cb61f54ae5efc53" }
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "b548d379dcbd67d29453d94847b7bc33ae92e673" }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "a055e4f79a10122c8c0c882161442e6e02f0c5c6" }
+littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "960e57d9fc0d209308c8e15dc26252bbe1ff6ba8" }
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
+trussed-fs-info = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "170ab14f3bb6760399749d78e1b94e3b70106739" }
 trussed-hkdf = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "hkdf-v0.2.0" }
-trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.0" }
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "170ab14f3bb6760399749d78e1b94e3b70106739" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.1" }
 usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid.git", rev = "dcff9009c3cd1ef9e5b09f8f307aca998fc9a8c8" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 ctap-types = { version = "0.2.0", features = ["arbitrary"] }
 libfuzzer-sys = "0.4"
-trussed-staging = { version = "0.3.0", features = ["chunked", "hkdf", "virt"] }
+trussed-staging = { version = "0.3.0", features = ["chunked", "hkdf", "virt", "fs-info"] }
 
 [dependencies.fido-authenticator]
 path = ".."
@@ -24,9 +24,11 @@ bench = false
 
 [patch.crates-io]
 ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "72eb68b61e3f14957c5ab89bd22f776ac860eb62" }
-littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "2b45a7559ff44260c6dd693e4cb61f54ae5efc53" }
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "b548d379dcbd67d29453d94847b7bc33ae92e673" }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "a055e4f79a10122c8c0c882161442e6e02f0c5c6" }
+littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "960e57d9fc0d209308c8e15dc26252bbe1ff6ba8" }
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
 trussed-hkdf = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "hkdf-v0.2.0" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.0" }
 cbor-smol = { git = "https://github.com/sosthene-nitrokey/cbor-smol.git", rev = "9a77dc9b528b08f531d76b44af2f5336c4ef17e0"}
+trussed-fs-info = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "170ab14f3bb6760399749d78e1b94e3b70106739" }
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "170ab14f3bb6760399749d78e1b94e3b70106739" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -28,7 +28,6 @@ trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "a055e4f79
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "960e57d9fc0d209308c8e15dc26252bbe1ff6ba8" }
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
 trussed-hkdf = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "hkdf-v0.2.0" }
-trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.0" }
 cbor-smol = { git = "https://github.com/sosthene-nitrokey/cbor-smol.git", rev = "9a77dc9b528b08f531d76b44af2f5336c4ef17e0"}
 trussed-fs-info = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "170ab14f3bb6760399749d78e1b94e3b70106739" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "170ab14f3bb6760399749d78e1b94e3b70106739" }

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -388,7 +388,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
             self.delete_resident_key_by_user_id(&rp_id_hash, &credential.user.id)
                 .ok();
 
-            let mut key_store_full = !self.can_fit(serialized_credential.len())
+            let mut key_store_full = self.can_fit(serialized_credential.len()) == Some(false)
                 || CredentialManagement::new(self).count_credentials()
                     >= self
                         .config

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -67,7 +67,7 @@ where
         let max_resident_credentials = self.estimate_remaining();
         response.existing_resident_credentials_count = Some(self.count_credentials());
         response.max_possible_remaining_residential_credentials_count =
-            Some(max_resident_credentials.try_into().unwrap_or(u32::MAX));
+            Some(max_resident_credentials);
 
         response
     }

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -15,7 +15,6 @@ use ctap_types::{
 };
 
 use crate::{
-    constants::MAX_RESIDENT_CREDENTIALS_GUESSTIMATE,
     credential::FullCredential,
     state::{CredentialManagementEnumerateCredentials, CredentialManagementEnumerateRps},
     Authenticator, Result, TrussedRequirements, UserPresence,
@@ -65,53 +64,12 @@ where
         info!("get metadata");
         let mut response: Response = Default::default();
 
-        let max_resident_credentials = self
-            .config
-            .max_resident_credential_count
-            .unwrap_or(MAX_RESIDENT_CREDENTIALS_GUESSTIMATE);
+        let max_resident_credentials = self.estimate_remaining();
         response.existing_resident_credentials_count = Some(0);
         response.max_possible_remaining_residential_credentials_count =
-            Some(max_resident_credentials);
+            Some(max_resident_credentials.try_into().unwrap_or(u32::MAX));
 
-        let dir = PathBuf::from(b"rk");
-        let maybe_first_rp =
-            syscall!(self
-                .trussed
-                .read_dir_first(Location::Internal, dir.clone(), None))
-            .entry;
-
-        let first_rp = match maybe_first_rp {
-            None => return response,
-            Some(rp) => rp,
-        };
-
-        let (mut num_rks, _) = self.count_rp_rks(PathBuf::from(first_rp.path()));
-        let mut last_rp = PathBuf::from(first_rp.file_name());
-
-        loop {
-            syscall!(self
-                .trussed
-                .read_dir_first(Location::Internal, dir.clone(), Some(last_rp),))
-            .entry
-            .unwrap();
-            let maybe_next_rp = syscall!(self.trussed.read_dir_next()).entry;
-
-            match maybe_next_rp {
-                None => {
-                    response.existing_resident_credentials_count = Some(num_rks);
-                    response.max_possible_remaining_residential_credentials_count =
-                        Some(max_resident_credentials.saturating_sub(num_rks));
-                    return response;
-                }
-                Some(rp) => {
-                    last_rp = PathBuf::from(rp.file_name());
-                    info!("counting..");
-                    let (this_rp_rk_count, _) = self.count_rp_rks(PathBuf::from(rp.path()));
-                    info!("{:?}", this_rp_rk_count);
-                    num_rks += this_rp_rk_count;
-                }
-            }
-        }
+        response
     }
 
     pub fn first_relying_party(&mut self) -> Result<Response> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,21 +275,21 @@ where
         }
     }
 
-    fn estimate_remaining_inner(info: &FsInfoReply) -> usize {
+    fn estimate_remaining_inner(info: &FsInfoReply) -> u32 {
         let block_size = info.block_info.as_ref().map(|i| i.size).unwrap_or(255);
         // 1 block for the directory, 1 for the private key, 400 bytes for a reasonnable key and metadata
         let size_taken = 2 * block_size + 400;
         // Remove 5 block kept as buffer
-        (info.available_space - 5 * block_size) / size_taken
+        ((info.available_space - 5 * block_size) / size_taken) as u32
     }
 
-    fn estimate_remaining(&mut self) -> usize {
+    fn estimate_remaining(&mut self) -> u32 {
         let info = syscall!(self.trussed.fs_info(Location::Internal));
         debug!("Got filesystem info: {info:?}");
         Self::estimate_remaining_inner(&info).min(
             self.config
                 .max_resident_credential_count
-                .unwrap_or(MAX_RESIDENT_CREDENTIALS_GUESSTIMATE) as usize,
+                .unwrap_or(MAX_RESIDENT_CREDENTIALS_GUESSTIMATE),
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,8 @@ where
     }
 
     /// Can a credential of size `size` be stored with safe margins
+    ///
+    /// This assumes that the key has already been generated and is stored.
     fn can_fit(&mut self, size: usize) -> Option<bool> {
         debug!("Can fit for {size} bytes");
         let info = syscall!(self.trussed.fs_info(Location::Internal));


### PR DESCRIPTION
The estimation is pretty rough and in most cases pessimistic. It reserves multiple blocks of margin to prevent filling up the device.

With the default configuration of the usbip runner, it estimates the value to be around 40, and I could generate more than 60.

For now, this PR removes the hard-coded limitation when generating credentials.
This makes credential generation faster, but at the same time this could prove to be an issue when listing credential (even the USBIP version is pretty slow to list all credentials).