### PR TITLE
Dilithium Assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ disable-reset-time-window = []
 # enables support for a large-blob array longer than 1024 bytes
 chunked = ["trussed-chunked"]
 
+backend-dilithium2 = ["ctap-types/backend-dilithium2", "trussed/backend-dilithium2"]
+backend-dilithium3 = ["ctap-types/backend-dilithium3", "trussed/backend-dilithium3"]
+backend-dilithium5 = ["ctap-types/backend-dilithium5", "trussed/backend-dilithium5"]
+
 log-all = []
 log-none = []
 log-info = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,10 @@ disable-reset-time-window = []
 # enables support for a large-blob array longer than 1024 bytes
 chunked = ["trussed-chunked"]
 
-backend-dilithium2 = ["ctap-types/backend-dilithium2", "trussed/backend-dilithium2"]
-backend-dilithium3 = ["ctap-types/backend-dilithium3", "trussed/backend-dilithium3"]
-backend-dilithium5 = ["ctap-types/backend-dilithium5", "trussed/backend-dilithium5"]
+backend-dilithium = []
+backend-dilithium2 = ["backend-dilithium", "ctap-types/backend-dilithium2", "trussed/backend-dilithium2"]
+backend-dilithium3 = ["backend-dilithium", "ctap-types/backend-dilithium3", "trussed/backend-dilithium3"]
+backend-dilithium5 = ["backend-dilithium", "ctap-types/backend-dilithium5", "trussed/backend-dilithium5"]
 
 log-all = []
 log-none = []

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -17,9 +17,12 @@ use trussed::{
     syscall, try_syscall,
     types::{
         KeyId, KeySerialization, Location, Mechanism, MediumData, Message, Path, PathBuf,
-        SignatureSerialization, StorageAttributes,
+        SignatureSerialization,
     },
 };
+
+#[cfg(feature = "backend-dilithium")]
+use trussed::types::StorageAttributes;
 
 use crate::{
     constants::{self, MAX_RESIDENT_CREDENTIALS_GUESSTIMATE},

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -4,8 +4,11 @@ use core::convert::TryFrom;
 
 use trussed::{
     syscall, try_syscall,
-    types::{DirEntry, Location, Path, PathBuf, StorageAttributes},
+    types::{DirEntry, Location, Path, PathBuf},
 };
+
+#[cfg(feature = "backend-dilithium")]
+use trussed::types::StorageAttributes;
 
 use cosey::PublicKey;
 use ctap_types::{

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -4,7 +4,7 @@ use core::convert::TryFrom;
 
 use trussed::{
     syscall, try_syscall,
-    types::{DirEntry, Location, Path, PathBuf},
+    types::{DirEntry, Location, Path, PathBuf, StorageAttributes},
 };
 
 use cosey::PublicKey;
@@ -440,6 +440,66 @@ where
                 .serialized_key;
                 syscall!(self.trussed.delete(public_key));
                 PublicKey::Ed25519Key(
+                    ctap_types::serde::cbor_deserialize(&cose_public_key).unwrap(),
+                )
+            }
+            #[cfg(feature = "backend-dilithium2")]
+            SigningAlgorithm::Dilithium2 => {
+                let public_key = syscall!(self.trussed.derive_key(
+                    Mechanism::Dilithium2,
+                    private_key,
+                    None,
+                    StorageAttributes::new().set_persistence(Location::Volatile),
+                ))
+                .key;
+                let cose_public_key = syscall!(self.trussed.serialize_key(
+                    Mechanism::Dilithium2,
+                    public_key,
+                    KeySerialization::Cose
+                ))
+                .serialized_key;
+                syscall!(self.trussed.delete(public_key));
+                PublicKey::Dilithium2(
+                    ctap_types::serde::cbor_deserialize(&cose_public_key).unwrap(),
+                )
+            }
+            #[cfg(feature = "backend-dilithium3")]
+            SigningAlgorithm::Dilithium3 => {
+                let public_key = syscall!(self.trussed.derive_key(
+                    Mechanism::Dilithium3,
+                    private_key,
+                    None,
+                    StorageAttributes::new().set_persistence(Location::Volatile),
+                ))
+                .key;
+                let cose_public_key = syscall!(self.trussed.serialize_key(
+                    Mechanism::Dilithium3,
+                    public_key,
+                    KeySerialization::Cose
+                ))
+                .serialized_key;
+                syscall!(self.trussed.delete(public_key));
+                PublicKey::Dilithium3(
+                    ctap_types::serde::cbor_deserialize(&cose_public_key).unwrap(),
+                )
+            }
+            #[cfg(feature = "backend-dilithium5")]
+            SigningAlgorithm::Dilithium5 => {
+                let public_key = syscall!(self.trussed.derive_key(
+                    Mechanism::Dilithium5,
+                    private_key,
+                    None,
+                    StorageAttributes::new().set_persistence(Location::Volatile),
+                ))
+                .key;
+                let cose_public_key = syscall!(self.trussed.serialize_key(
+                    Mechanism::Dilithium5,
+                    public_key,
+                    KeySerialization::Cose
+                ))
+                .serialized_key;
+                syscall!(self.trussed.delete(public_key));
+                PublicKey::Dilithium5(
                     ctap_types::serde::cbor_deserialize(&cose_public_key).unwrap(),
                 )
             } // SigningAlgorithm::Totp => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,12 @@ pub enum SigningAlgorithm {
     P256 = -7,
     // #[doc(hidden)]
     // Totp = -9,
+    #[cfg(feature = "backend-dilithium2")]
+    Dilithium2 = -87,
+    #[cfg(feature = "backend-dilithium3")]
+    Dilithium3 = -88,
+    #[cfg(feature = "backend-dilithium3")]
+    Dilithium5 = -89,
 }
 
 impl core::convert::TryFrom<i32> for SigningAlgorithm {
@@ -201,6 +207,12 @@ impl core::convert::TryFrom<i32> for SigningAlgorithm {
             -7 => SigningAlgorithm::P256,
             -8 => SigningAlgorithm::Ed25519,
             // -9 => SigningAlgorithm::Totp,
+            #[cfg(feature = "backend-dilithium2")]
+            -87 => SigningAlgorithm::Dilithium2,
+            #[cfg(feature = "backend-dilithium3")]
+            -88 => SigningAlgorithm::Dilithium3,
+            #[cfg(feature = "backend-dilithium5")]
+            -89 => SigningAlgorithm::Dilithium5,
             _ => return Err(Error::UnsupportedAlgorithm),
         })
     }


### PR DESCRIPTION
This PR adds support for post-quantum cryptography.

Done:
- Dilithium 2/3/5 for FIDO2 assertions

TODO:
- Kyber for PIN secret exchange
- PQC for attestations