### PR TITLE
Use apdu-app instead of apdu-dispatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "usbip"
 required-features = ["dispatch"]
 
 [dependencies]
-ctap-types = { version = "0.3.0", features = ["get-info-full", "large-blobs", "third-party-payment"] }
+ctap-types = { version = "0.3.1", features = ["get-info-full", "large-blobs", "third-party-payment"] }
 cosey = "0.3"
 delog = "0.1.0"
 heapless = "0.7"
@@ -28,7 +28,7 @@ trussed-fs-info = "0.1.0"
 trussed-hkdf = { version = "0.2.0" }
 trussed-chunked = { version = "0.1.0", optional = true }
 
-apdu-dispatch = { version = "0.1", optional = true }
+apdu-app = { version = "0.1", optional = true }
 ctaphid-dispatch = { version = "0.1", optional = true }
 iso7816 = { version = "0.1.2", optional = true }
 
@@ -36,6 +36,7 @@ cbor-smol = { version = "0.4.1" }
 
 [features]
 dispatch = ["apdu-dispatch", "ctaphid-dispatch", "iso7816"]
+apdu-dispatch = ["dep:apdu-app"]
 disable-reset-time-window = []
 
 # enables support for a large-blob array longer than 1024 bytes
@@ -77,7 +78,6 @@ features = ["dispatch"]
 
 [patch.crates-io]
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
-apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "915fc237103fcecc29d0f0b73391f19abf6576de" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "a055e4f79a10122c8c0c882161442e6e02f0c5c6" }
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "960e57d9fc0d209308c8e15dc26252bbe1ff6ba8" }
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }


### PR DESCRIPTION
Note:  I kept the `apdu-dispatch` feature name for consistency with `ctaphid-dispatch` and because we’re used to it.  Can potentially be changed in the future.