### PR TITLE
tests: Add credential management tests

### DIFF
--- a/tests/authenticator/mod.rs
+++ b/tests/authenticator/mod.rs
@@ -1,0 +1,196 @@
+use sha2::{Digest as _, Sha256};
+
+use super::{
+    virt::{Ctap2, Ctap2Error},
+    webauthn::{
+        AttStmtFormat, ClientPin, CredentialData, CredentialManagement, CredentialManagementParams,
+        KeyAgreementKey, MakeCredential, MakeCredentialOptions, PinToken, PubKeyCredParam,
+        PublicKey, Rp, SharedSecret, User,
+    },
+};
+
+pub struct Authenticator<'a, P: PinState> {
+    ctap2: Ctap2<'a>,
+    key_agreement_key: KeyAgreementKey,
+    shared_secret: Option<SharedSecret>,
+    pin: P,
+}
+
+impl<'a> Authenticator<'a, NoPin> {
+    pub fn new(ctap2: Ctap2<'a>) -> Self {
+        Self {
+            ctap2,
+            key_agreement_key: KeyAgreementKey::generate(),
+            shared_secret: None,
+            pin: NoPin,
+        }
+    }
+
+    pub fn set_pin(mut self, pin: &[u8]) -> Authenticator<'a, Pin> {
+        let shared_secret = self.shared_secret();
+        let mut padded_pin = [0; 64];
+        padded_pin[..pin.len()].copy_from_slice(pin);
+        let pin_enc = shared_secret.encrypt(&padded_pin);
+        let pin_auth = shared_secret.authenticate(&pin_enc);
+        let mut request = ClientPin::new(2, 3);
+        request.key_agreement = Some(self.key_agreement_key.public_key());
+        request.new_pin_enc = Some(pin_enc);
+        request.pin_auth = Some(pin_auth);
+        self.ctap2.exec(request).unwrap();
+        Authenticator {
+            ctap2: self.ctap2,
+            key_agreement_key: self.key_agreement_key,
+            shared_secret: self.shared_secret,
+            pin: Pin(pin.into()),
+        }
+    }
+}
+
+impl<'a, P: PinState> Authenticator<'a, P> {
+    fn shared_secret(&mut self) -> &SharedSecret {
+        self.shared_secret.get_or_insert_with(|| {
+            let reply = self.ctap2.exec(ClientPin::new(2, 2)).unwrap();
+            let authenticator_key_agreement: PublicKey = reply.key_agreement.unwrap().into();
+            self.key_agreement_key
+                .shared_secret(&authenticator_key_agreement)
+        })
+    }
+}
+
+impl<'a> Authenticator<'a, Pin> {
+    fn get_pin_token(&mut self, permissions: u8, rp_id: Option<String>) -> PinToken {
+        let mut hasher = Sha256::new();
+        hasher.update(&self.pin.0);
+        let pin_hash = hasher.finalize();
+        let pin_hash_enc = self.shared_secret().encrypt(&pin_hash[..16]);
+        let mut request = ClientPin::new(2, 9);
+        request.key_agreement = Some(self.key_agreement_key.public_key());
+        request.pin_hash_enc = Some(pin_hash_enc);
+        request.permissions = Some(permissions);
+        request.rp_id = rp_id;
+        let reply = self.ctap2.exec(request).unwrap();
+        let encrypted_pin_token = reply.pin_token.as_ref().unwrap().as_bytes().unwrap();
+        self.shared_secret().decrypt_pin_token(encrypted_pin_token)
+    }
+
+    pub fn make_credential(&mut self, rp: Rp, user: User) -> Result<CredentialData, Ctap2Error> {
+        let pin_token = self.get_pin_token(0x01, None);
+        // TODO: client data
+        let client_data_hash = b"";
+        let pin_auth = pin_token.authenticate(client_data_hash);
+        let pub_key_cred_params = vec![PubKeyCredParam::new("public-key", -7)];
+        let mut request = MakeCredential::new(client_data_hash, rp, user, pub_key_cred_params);
+        request.options = Some(MakeCredentialOptions::default().rk(true));
+        request.pin_auth = Some(pin_auth);
+        request.pin_protocol = Some(2);
+        let reply = self.ctap2.exec(request)?;
+        assert_eq!(
+            reply.auth_data.flags & 0b1,
+            0b1,
+            "up flag not set in auth_data: 0b{:b}",
+            reply.auth_data.flags
+        );
+        assert_eq!(
+            reply.auth_data.flags & 0b100,
+            0b100,
+            "uv flag not set in auth_data: 0b{:b}",
+            reply.auth_data.flags
+        );
+        let format = AttStmtFormat::Packed;
+        assert_eq!(reply.fmt, format.as_str());
+        reply.att_stmt.unwrap().validate(format, &reply.auth_data);
+        Ok(reply.auth_data.credential.unwrap())
+    }
+
+    fn credential_management(&mut self, subcommand: u8) -> CredentialManagement {
+        let pin_token = self.get_pin_token(0x04, None);
+        let pin_auth = pin_token.authenticate(&[subcommand]);
+        CredentialManagement {
+            subcommand,
+            subcommand_params: None,
+            pin_protocol: Some(2),
+            pin_auth: Some(pin_auth),
+        }
+    }
+
+    pub fn credentials_metadata(&mut self) -> CredentialsMetadata {
+        let request = self.credential_management(0x01);
+        let reply = self.ctap2.exec(request).unwrap();
+        CredentialsMetadata {
+            existing: reply.existing_resident_credentials_count.unwrap(),
+            remaining: reply
+                .max_possible_remaining_resident_credentials_count
+                .unwrap(),
+        }
+    }
+
+    pub fn list_rps(&mut self) -> Vec<Rp> {
+        let request = self.credential_management(0x02);
+        let reply = self.ctap2.exec(request).unwrap();
+        // TODO: check RP ID hash
+        let total_rps = reply.total_rps.unwrap();
+        let mut rps = Vec::with_capacity(total_rps);
+        rps.push(reply.rp.unwrap().into());
+
+        for _ in 1..total_rps {
+            let request = CredentialManagement::new(0x03);
+            let reply = self.ctap2.exec(request).unwrap();
+            // TODO: check RP ID hash
+            rps.push(reply.rp.unwrap().into());
+        }
+
+        rps
+    }
+
+    pub fn list_credentials(&mut self, rp_id: &str) -> Vec<User> {
+        let rp_id_hash = rp_id_hash(rp_id);
+        let pin_token = self.get_pin_token(0x04, Some(rp_id.to_owned()));
+        let params = CredentialManagementParams {
+            rp_id_hash: rp_id_hash.to_vec(),
+        };
+        let mut pin_auth_param = vec![0x04];
+        pin_auth_param.extend_from_slice(&params.serialized());
+        let pin_auth = pin_token.authenticate(&pin_auth_param);
+        let request = CredentialManagement {
+            subcommand: 0x04,
+            subcommand_params: Some(params),
+            pin_protocol: Some(2),
+            pin_auth: Some(pin_auth),
+        };
+        let reply = self.ctap2.exec(request).unwrap();
+        // TODO: check other fields
+        let total_credentials = reply.total_credentials.unwrap();
+        let mut credentials = Vec::with_capacity(total_credentials);
+        credentials.push(reply.user.unwrap().into());
+
+        for _ in 1..total_credentials {
+            let request = CredentialManagement::new(0x05);
+            let reply = self.ctap2.exec(request).unwrap();
+            // TODO: check other fields
+            credentials.push(reply.user.unwrap().into());
+        }
+
+        credentials
+    }
+}
+
+pub struct CredentialsMetadata {
+    pub existing: usize,
+    pub remaining: usize,
+}
+
+pub trait PinState {}
+
+pub struct NoPin;
+
+impl PinState for NoPin {}
+
+pub struct Pin(Vec<u8>);
+
+impl PinState for Pin {}
+
+fn rp_id_hash(rp_id: &str) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(rp_id);
+    hasher.finalize().into()
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "dispatch")]
 
-mod virt;
-mod webauthn;
+pub mod virt;
+pub mod webauthn;
 
 use std::collections::BTreeMap;
 
@@ -437,8 +437,8 @@ impl TestListCredentials {
             let request = CredentialManagement {
                 subcommand: 0x02,
                 subcommand_params: None,
-                pin_protocol: 2,
-                pin_auth,
+                pin_protocol: Some(2),
+                pin_auth: Some(pin_auth),
             };
             let reply = device.exec(request).unwrap();
             let rp: BTreeMap<String, Value> = reply.rp.unwrap().deserialized().unwrap();
@@ -465,8 +465,8 @@ impl TestListCredentials {
             let request = CredentialManagement {
                 subcommand: 0x04,
                 subcommand_params: Some(params),
-                pin_protocol: 2,
-                pin_auth,
+                pin_protocol: Some(2),
+                pin_auth: Some(pin_auth),
             };
             let reply = device.exec(request).unwrap();
             let user: BTreeMap<String, Value> = reply.user.unwrap().deserialized().unwrap();

--- a/tests/cred_mgmt.rs
+++ b/tests/cred_mgmt.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "dispatch")]
+
+pub mod authenticator;
+pub mod virt;
+pub mod webauthn;
+
+use std::collections::BTreeMap;
+
+use littlefs2::path::PathBuf;
+
+use authenticator::Authenticator;
+use virt::{Ctap2Error, Options};
+use webauthn::{Rp, User};
+
+#[test]
+fn test_list_credentials() {
+    virt::run_ctap2(|device| {
+        let mut authenticator = Authenticator::new(device).set_pin(b"123456");
+        let mut credentials: BTreeMap<_, _> = (0..10)
+            .map(|i| {
+                // TODO: set other fields than id
+                let rp_id = format!("rp{i}");
+                let user = b"john.doe";
+                authenticator
+                    .make_credential(Rp::new(rp_id.clone()), User::new(user))
+                    .unwrap();
+                (rp_id, user)
+            })
+            .collect();
+
+        let rps = authenticator.list_rps();
+        assert_eq!(rps.len(), 10);
+        for rp in &rps {
+            assert_eq!(rp.name, None);
+            let expected = credentials.remove(&rp.id).unwrap();
+
+            let mut credentials = authenticator.list_credentials(&rp.id);
+            assert_eq!(credentials.len(), 1);
+            let actual = credentials.pop().unwrap();
+
+            assert_eq!(actual.id, expected);
+            assert_eq!(actual.name, None);
+            assert_eq!(actual.display_name, None);
+        }
+        assert!(credentials.is_empty());
+    })
+}
+
+#[test]
+fn test_max_credential_count() {
+    let options = Options {
+        max_resident_credential_count: Some(10),
+        ..Default::default()
+    };
+    virt::run_ctap2_with_options(options, |device| {
+        let mut authenticator = Authenticator::new(device).set_pin(b"123456");
+        let metadata = authenticator.credentials_metadata();
+        assert_eq!(metadata.existing, 0);
+        // TODO: check metadata.remaining -- currently not checking the config properly
+
+        for i in 0..10 {
+            let rp = Rp::new(format!("rp{i}"));
+            let user = User::new(b"john.doe");
+            authenticator.make_credential(rp, user).unwrap();
+
+            let metadata = authenticator.credentials_metadata();
+            assert_eq!(metadata.existing, i + 1);
+            // TODO: check metadata.remaining
+        }
+
+        let rps = authenticator.list_rps();
+        assert_eq!(rps.len(), 10);
+        for rp in &rps {
+            let credentials = authenticator.list_credentials(&rp.id);
+            assert_eq!(credentials.len(), 1);
+        }
+
+        let rp = Rp::new("rp11");
+        let user = User::new(b"john.doe");
+        let result = authenticator.make_credential(rp, user);
+        assert_eq!(result, Err(Ctap2Error(0x28)));
+
+        let rps = authenticator.list_rps();
+        assert_eq!(rps.len(), 10);
+        for rp in &rps {
+            let credentials = authenticator.list_credentials(&rp.id);
+            assert_eq!(credentials.len(), 1);
+        }
+    })
+}
+
+#[test]
+fn test_filesystem_full() {
+    let mut options = Options {
+        max_resident_credential_count: Some(10),
+        ..Default::default()
+    };
+    for i in 0..80 {
+        let path = PathBuf::from(format!("/test/{i}").as_str());
+        options.files.push((path, vec![0; 512]));
+    }
+    // TODO: inspect filesystem after run and check remaining blocks
+    virt::run_ctap2_with_options(options, |device| {
+        let mut authenticator = Authenticator::new(device).set_pin(b"123456");
+        let metadata = authenticator.credentials_metadata();
+        assert_eq!(metadata.existing, 0);
+        // This number depends on filesystem layout details and may change if the filesystem
+        // layout or implementation are changed.
+        assert_eq!(metadata.remaining, 5);
+        let n = metadata.remaining;
+
+        let mut i = 0;
+        loop {
+            let rp = Rp::new(format!("rp{i}"));
+            let user = User::new(b"john.doe");
+            let result = authenticator.make_credential(rp, user);
+
+            if result == Err(Ctap2Error(0x28)) {
+                break;
+            }
+            result.unwrap();
+
+            let metadata = authenticator.credentials_metadata();
+            assert_eq!(metadata.existing, i + 1);
+
+            i += 1;
+        }
+
+        // We should be able to create at least 1 but not more than n credentials.
+        assert!(i > 0);
+        assert!(i < n);
+        // Our estimate should not be more than one credential off.
+        assert!(n - i <= 1);
+
+        let metadata = authenticator.credentials_metadata();
+        assert_eq!(metadata.existing, i);
+        assert_eq!(metadata.remaining, 0);
+    })
+}


### PR DESCRIPTION
This patch introduces the authenticator module that provides a simple high-level interface for testing FIDO2 functionality.  It uses the module to implement tests for credential management, namely for listing credentials and for the behavior if the credential limit is reached or the filesystem is full.