### PR TITLE
Remove cbor_serialize_message helper

### DIFF
--- a/src/ctap2/pin.rs
+++ b/src/ctap2/pin.rs
@@ -1,8 +1,8 @@
-use crate::{cbor_serialize_message, TrussedRequirements};
+use crate::TrussedRequirements;
 use cosey::EcdhEsHkdf256PublicKey;
 use ctap_types::{ctap2::client_pin::Permissions, Error, Result};
 use trussed::{
-    cbor_deserialize,
+    cbor_deserialize, cbor_serialize_bytes,
     client::{CryptoClient, HmacSha256, P256},
     syscall, try_syscall,
     types::{
@@ -312,7 +312,7 @@ impl<'a, T: TrussedRequirements> PinProtocol<'a, T> {
     }
 
     fn shared_secret_impl(&mut self, peer_key: &EcdhEsHkdf256PublicKey) -> Option<SharedSecret> {
-        let serialized_peer_key = cbor_serialize_message(peer_key).ok()?;
+        let serialized_peer_key: Message = cbor_serialize_bytes(peer_key).ok()?;
         let peer_key = try_syscall!(self.trussed.deserialize_p256_key(
             &serialized_peer_key,
             KeySerialization::EcdhEsHkdf256,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,7 @@ generate_macros!();
 
 use core::time::Duration;
 
-use trussed::{
-    client, syscall,
-    types::{Location, Message},
-    Client as TrussedClient,
-};
+use trussed::{client, syscall, types::Location, Client as TrussedClient};
 use trussed_fs_info::{FsInfoClient, FsInfoReply};
 use trussed_hkdf::HkdfClient;
 
@@ -250,12 +246,6 @@ impl UserPresence for Conforming {
             _ => Error::OperationDenied,
         })
     }
-}
-
-fn cbor_serialize_message<T: serde::Serialize>(
-    object: &T,
-) -> core::result::Result<Message, ctap_types::serde::Error> {
-    trussed::cbor_serialize_bytes(object)
 }
 
 impl<UP, T> Authenticator<UP, T>

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,7 +11,7 @@ use ctap_types::{
 };
 use littlefs2_core::path;
 use trussed::{
-    client, syscall, try_syscall,
+    cbor_serialize_bytes, client, syscall, try_syscall,
     types::{KeyId, Location, Mechanism, Path, PathBuf},
     Client as TrussedClient,
 };
@@ -299,7 +299,7 @@ impl PersistentState {
     }
 
     pub fn save<T: TrussedClient>(&self, trussed: &mut T) -> Result<()> {
-        let data = crate::cbor_serialize_message(self).unwrap();
+        let data = cbor_serialize_bytes(self).unwrap();
 
         syscall!(trussed.write_file(
             Location::Internal,


### PR DESCRIPTION
The cbor_serialize_message helper mixed re-exports of cbor-smol from trussed and ctap-types.  This can be problematic if both select different versions.  It could be fixed by keeping both in sync, but to avoid this problem entirely, we can also just use cbor_serialize_bytes from Trussed directly.