### PR TITLE
Dilithium Assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ disable-reset-time-window = []
 # enables support for a large-blob array longer than 1024 bytes
 chunked = ["trussed-chunked"]
 
+backend-dilithium2 = ["ctap-types/backend-dilithium2", "trussed/backend-dilithium2"]
+backend-dilithium3 = ["ctap-types/backend-dilithium3", "trussed/backend-dilithium3"]
+backend-dilithium5 = ["ctap-types/backend-dilithium5", "trussed/backend-dilithium5"]
+
 log-all = []
 log-none = []
 log-info = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,10 @@ disable-reset-time-window = []
 # enables support for a large-blob array longer than 1024 bytes
 chunked = ["trussed-chunked"]
 
-backend-dilithium2 = ["ctap-types/backend-dilithium2", "trussed/backend-dilithium2"]
-backend-dilithium3 = ["ctap-types/backend-dilithium3", "trussed/backend-dilithium3"]
-backend-dilithium5 = ["ctap-types/backend-dilithium5", "trussed/backend-dilithium5"]
+backend-dilithium = []
+backend-dilithium2 = ["backend-dilithium", "ctap-types/backend-dilithium2", "trussed/backend-dilithium2"]
+backend-dilithium3 = ["backend-dilithium", "ctap-types/backend-dilithium3", "trussed/backend-dilithium3"]
+backend-dilithium5 = ["backend-dilithium", "ctap-types/backend-dilithium5", "trussed/backend-dilithium5"]
 
 log-all = []
 log-none = []

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -308,7 +308,7 @@ pub struct CredentialData {
     pub creation_time: u32,
     // for stateless deterministic keys, it seems CTAP2 (but not CTAP1) makes signature counters optional
     use_counter: bool,
-    // P256 or Ed25519
+    // P256, Ed25519, or Dilithium 2/3/5
     pub algorithm: i32,
     // for RK in non-deterministic mode: refers to actual key
     // TODO(implement enums in cbor-deser): for all others, is a wrapped key

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -4,6 +4,7 @@ use core::cmp::Ordering;
 
 use serde::Serialize;
 use serde_bytes::ByteArray;
+use trussed::config::MAX_FIDO_WRAPPED_KEY_LENGTH;
 use trussed::{client, syscall, try_syscall, types::KeyId};
 
 pub(crate) use ctap_types::{
@@ -95,7 +96,7 @@ impl TryFrom<CredentialId> for EncryptedSerializedCredential {
 pub enum Key {
     ResidentKey(KeyId),
     // THIS USED TO BE 92 NOW IT'S 96 or 97 or so... waddup?
-    WrappedKey(Bytes<128>),
+    WrappedKey(Bytes<MAX_FIDO_WRAPPED_KEY_LENGTH>),
 }
 
 /// A credential that is managed by the authenticator.

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -9,7 +9,9 @@ use ctap_types::{
     },
     heapless::{String, Vec},
     heapless_bytes::Bytes,
-    sizes, ByteArray, Error,
+    sizes,
+    sizes::MAX_COMMITTMENT_LENGTH,
+    ByteArray, Error,
 };
 use littlefs2_core::path;
 use sha2::{Digest as _, Sha256};
@@ -517,7 +519,11 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
             sign_count: self.state.persistent.timestamp(&mut self.trussed)?,
 
             attested_credential_data: {
-                // debug_now!("acd in, cid len {}, pk len {}", credential_id.0.len(), cose_public_key.len());
+                debug_now!(
+                    "acd in, cid len {}, pk len {}",
+                    credential_id.0.len(),
+                    cose_public_key.len()
+                );
                 let attested_credential_data = ctap2::make_credential::AttestedCredentialData {
                     aaguid: &aaguid,
                     credential_id: &credential_id.0,
@@ -554,7 +560,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
                     Some(AttestationStatement::None(NoneAttestationStatement {}))
                 }
                 SupportedAttestationFormat::Packed => {
-                    let mut commitment = Bytes::<1024>::new();
+                    let mut commitment = Bytes::<MAX_COMMITTMENT_LENGTH>::new();
                     commitment
                         .extend_from_slice(&serialized_auth_data)
                         .map_err(|_| Error::Other)?;

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -18,9 +18,12 @@ use trussed::{
     syscall, try_syscall,
     types::{
         KeyId, KeySerialization, Location, Mechanism, MediumData, Message, Path, PathBuf,
-        SignatureSerialization, StorageAttributes,
+        SignatureSerialization,
     },
 };
+
+#[cfg(feature = "backend-dilithium")]
+use trussed::types::StorageAttributes;
 
 use crate::{
     constants::{self, MAX_RESIDENT_CREDENTIALS_GUESSTIMATE},

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -18,7 +18,7 @@ use trussed::{
     syscall, try_syscall,
     types::{
         KeyId, KeySerialization, Location, Mechanism, MediumData, Message, Path, PathBuf,
-        SignatureSerialization,
+        SignatureSerialization, StorageAttributes,
     },
 };
 
@@ -305,6 +305,78 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
                 .serialized_key;
                 let _success = syscall!(self.trussed.delete(public_key)).success;
                 info_now!("deleted public Ed25519 key: {}", _success);
+            }
+            #[cfg(feature = "backend-dilithium2")]
+            SigningAlgorithm::Dilithium2 => {
+                private_key = syscall!(self.trussed.generate_key(
+                    Mechanism::Dilithium2,
+                    StorageAttributes::new().set_persistence(location)
+                ))
+                .key;
+                public_key = syscall!(self.trussed.derive_key(
+                    Mechanism::Dilithium2,
+                    private_key,
+                    None,
+                    StorageAttributes::new().set_persistence(Location::Volatile),
+                ))
+                .key;
+                cose_public_key = syscall!(self.trussed.serialize_key(
+                    Mechanism::Dilithium2,
+                    public_key,
+                    KeySerialization::Cose
+                ))
+                .serialized_key;
+
+                let _success = syscall!(self.trussed.delete(public_key)).success;
+                info_now!("deleted public Dilithium2 key: {}", _success);
+            }
+            #[cfg(feature = "backend-dilithium3")]
+            SigningAlgorithm::Dilithium3 => {
+                private_key = syscall!(self.trussed.generate_key(
+                    Mechanism::Dilithium3,
+                    StorageAttributes::new().set_persistence(location)
+                ))
+                .key;
+                public_key = syscall!(self.trussed.derive_key(
+                    Mechanism::Dilithium3,
+                    private_key,
+                    None,
+                    StorageAttributes::new().set_persistence(Location::Volatile),
+                ))
+                .key;
+                cose_public_key = syscall!(self.trussed.serialize_key(
+                    Mechanism::Dilithium3,
+                    public_key,
+                    KeySerialization::Cose
+                ))
+                .serialized_key;
+
+                let _success = syscall!(self.trussed.delete(public_key)).success;
+                info_now!("deleted public Dilithium3 key: {}", _success);
+            }
+            #[cfg(feature = "backend-dilithium5")]
+            SigningAlgorithm::Dilithium5 => {
+                private_key = syscall!(self.trussed.generate_key(
+                    Mechanism::Dilithium5,
+                    StorageAttributes::new().set_persistence(location)
+                ))
+                .key;
+                public_key = syscall!(self.trussed.derive_key(
+                    Mechanism::Dilithium5,
+                    private_key,
+                    None,
+                    StorageAttributes::new().set_persistence(Location::Volatile),
+                ))
+                .key;
+                cose_public_key = syscall!(self.trussed.serialize_key(
+                    Mechanism::Dilithium5,
+                    public_key,
+                    KeySerialization::Cose
+                ))
+                .serialized_key;
+
+                let _success = syscall!(self.trussed.delete(public_key)).success;
+                info_now!("deleted public Dilithium5 key: {}", _success);
             } // SigningAlgorithm::Totp => {
               //     if parameters.client_data_hash.len() != 32 {
               //         return Err(Error::InvalidParameter);
@@ -522,6 +594,49 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
                                     ))
                                     .signature;
                                     (der_signature.to_bytes().map_err(|_| Error::Other)?, -7)
+                                }
+
+                                #[cfg(feature = "backend-dilithium2")]
+                                SigningAlgorithm::Dilithium2 => {
+                                    let signature = syscall!(self.trussed.sign(
+                                        Mechanism::Dilithium2,
+                                        private_key,
+                                        &commitment,
+                                        SignatureSerialization::Raw
+                                    ))
+                                    .signature;
+                                    (
+                                        signature.to_bytes().map_err(|_| Error::Other)?,
+                                        SigningAlgorithm::Dilithium2 as i32,
+                                    )
+                                }
+                                #[cfg(feature = "backend-dilithium3")]
+                                SigningAlgorithm::Dilithium3 => {
+                                    let signature = syscall!(self.trussed.sign(
+                                        Mechanism::Dilithium3,
+                                        private_key,
+                                        &commitment,
+                                        SignatureSerialization::Raw
+                                    ))
+                                    .signature;
+                                    (
+                                        signature.to_bytes().map_err(|_| Error::Other)?,
+                                        SigningAlgorithm::Dilithium3 as i32,
+                                    )
+                                }
+                                #[cfg(feature = "backend-dilithium5")]
+                                SigningAlgorithm::Dilithium5 => {
+                                    let signature = syscall!(self.trussed.sign(
+                                        Mechanism::Dilithium5,
+                                        private_key,
+                                        &commitment,
+                                        SignatureSerialization::Raw
+                                    ))
+                                    .signature;
+                                    (
+                                        signature.to_bytes().map_err(|_| Error::Other)?,
+                                        SigningAlgorithm::Dilithium5 as i32,
+                                    )
                                 }
                             }
                         }

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -4,7 +4,7 @@ use core::{cmp, convert::TryFrom};
 
 use trussed::{
     syscall, try_syscall,
-    types::{DirEntry, Location, Path, PathBuf},
+    types::{DirEntry, Location, Path, PathBuf, StorageAttributes},
 };
 
 use cosey::PublicKey;
@@ -444,6 +444,66 @@ where
                 .serialized_key;
                 syscall!(self.trussed.delete(public_key));
                 PublicKey::Ed25519Key(
+                    ctap_types::serde::cbor_deserialize(&cose_public_key).unwrap(),
+                )
+            }
+            #[cfg(feature = "backend-dilithium2")]
+            SigningAlgorithm::Dilithium2 => {
+                let public_key = syscall!(self.trussed.derive_key(
+                    Mechanism::Dilithium2,
+                    private_key,
+                    None,
+                    StorageAttributes::new().set_persistence(Location::Volatile),
+                ))
+                .key;
+                let cose_public_key = syscall!(self.trussed.serialize_key(
+                    Mechanism::Dilithium2,
+                    public_key,
+                    KeySerialization::Cose
+                ))
+                .serialized_key;
+                syscall!(self.trussed.delete(public_key));
+                PublicKey::Dilithium2(
+                    ctap_types::serde::cbor_deserialize(&cose_public_key).unwrap(),
+                )
+            }
+            #[cfg(feature = "backend-dilithium3")]
+            SigningAlgorithm::Dilithium3 => {
+                let public_key = syscall!(self.trussed.derive_key(
+                    Mechanism::Dilithium3,
+                    private_key,
+                    None,
+                    StorageAttributes::new().set_persistence(Location::Volatile),
+                ))
+                .key;
+                let cose_public_key = syscall!(self.trussed.serialize_key(
+                    Mechanism::Dilithium3,
+                    public_key,
+                    KeySerialization::Cose
+                ))
+                .serialized_key;
+                syscall!(self.trussed.delete(public_key));
+                PublicKey::Dilithium3(
+                    ctap_types::serde::cbor_deserialize(&cose_public_key).unwrap(),
+                )
+            }
+            #[cfg(feature = "backend-dilithium5")]
+            SigningAlgorithm::Dilithium5 => {
+                let public_key = syscall!(self.trussed.derive_key(
+                    Mechanism::Dilithium5,
+                    private_key,
+                    None,
+                    StorageAttributes::new().set_persistence(Location::Volatile),
+                ))
+                .key;
+                let cose_public_key = syscall!(self.trussed.serialize_key(
+                    Mechanism::Dilithium5,
+                    public_key,
+                    KeySerialization::Cose
+                ))
+                .serialized_key;
+                syscall!(self.trussed.delete(public_key));
+                PublicKey::Dilithium5(
                     ctap_types::serde::cbor_deserialize(&cose_public_key).unwrap(),
                 )
             } // SigningAlgorithm::Totp => {

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -4,8 +4,11 @@ use core::{cmp, convert::TryFrom};
 
 use trussed::{
     syscall, try_syscall,
-    types::{DirEntry, Location, Path, PathBuf, StorageAttributes},
+    types::{DirEntry, Location, Path, PathBuf},
 };
+
+#[cfg(feature = "backend-dilithium")]
+use trussed::types::StorageAttributes;
 
 use cosey::PublicKey;
 use ctap_types::{

--- a/src/ctap2/pin.rs
+++ b/src/ctap2/pin.rs
@@ -4,6 +4,7 @@ use ctap_types::{ctap2::client_pin::Permissions, Error, Result};
 use trussed::{
     cbor_deserialize, cbor_serialize_bytes,
     client::{CryptoClient, HmacSha256, P256},
+    config::MAX_MESSAGE_LENGTH,
     syscall, try_syscall,
     types::{
         Bytes, KeyId, KeySerialization, Location, Mechanism, Message, ShortData, StorageAttributes,
@@ -429,7 +430,11 @@ impl SharedSecret {
     }
 
     #[must_use]
-    pub fn encrypt<T: CryptoClient>(&self, trussed: &mut T, data: &[u8]) -> Bytes<1024> {
+    pub fn encrypt<T: CryptoClient>(
+        &self,
+        trussed: &mut T,
+        data: &[u8],
+    ) -> Bytes<MAX_MESSAGE_LENGTH> {
         let key_id = self.aes_key_id();
         let iv = self.generate_iv(trussed);
         let mut ciphertext =
@@ -442,7 +447,7 @@ impl SharedSecret {
     }
 
     #[must_use]
-    fn wrap<T: CryptoClient>(&self, trussed: &mut T, key: KeyId) -> Bytes<1024> {
+    fn wrap<T: CryptoClient>(&self, trussed: &mut T, key: KeyId) -> Bytes<MAX_MESSAGE_LENGTH> {
         let wrapping_key = self.aes_key_id();
         let iv = self.generate_iv(trussed);
         let mut wrapped_key = syscall!(trussed.wrap_key(
@@ -460,7 +465,11 @@ impl SharedSecret {
     }
 
     #[must_use]
-    pub fn decrypt<T: CryptoClient>(&self, trussed: &mut T, data: &[u8]) -> Option<Bytes<1024>> {
+    pub fn decrypt<T: CryptoClient>(
+        &self,
+        trussed: &mut T,
+        data: &[u8],
+    ) -> Option<Bytes<MAX_MESSAGE_LENGTH>> {
         let key_id = self.aes_key_id();
         let (iv, data) = match self {
             Self::V1 { .. } => (Default::default(), data),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,12 @@ pub enum SigningAlgorithm {
     P256 = -7,
     // #[doc(hidden)]
     // Totp = -9,
+    #[cfg(feature = "backend-dilithium2")]
+    Dilithium2 = -87,
+    #[cfg(feature = "backend-dilithium3")]
+    Dilithium3 = -88,
+    #[cfg(feature = "backend-dilithium3")]
+    Dilithium5 = -89,
 }
 
 impl core::convert::TryFrom<i32> for SigningAlgorithm {
@@ -197,6 +203,12 @@ impl core::convert::TryFrom<i32> for SigningAlgorithm {
             -7 => SigningAlgorithm::P256,
             -8 => SigningAlgorithm::Ed25519,
             // -9 => SigningAlgorithm::Totp,
+            #[cfg(feature = "backend-dilithium2")]
+            -87 => SigningAlgorithm::Dilithium2,
+            #[cfg(feature = "backend-dilithium3")]
+            -88 => SigningAlgorithm::Dilithium3,
+            #[cfg(feature = "backend-dilithium5")]
+            -89 => SigningAlgorithm::Dilithium5,
             _ => return Err(Error::UnsupportedAlgorithm),
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ pub(crate) fn msp() -> u32 {
     0x2000_0000
 }
 
-/// Currently Ed25519 and P256.
+/// Currently Ed25519, P256, and Dilithium 2/3/5
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(i32)]
 #[non_exhaustive]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub enum SigningAlgorithm {
     Dilithium2 = -87,
     #[cfg(feature = "backend-dilithium3")]
     Dilithium3 = -88,
-    #[cfg(feature = "backend-dilithium3")]
+    #[cfg(feature = "backend-dilithium5")]
     Dilithium5 = -89,
 }
 


### PR DESCRIPTION
This PR adds support for post-quantum cryptography.

Done:
- Dilithium 2/3/5 for FIDO2 assertions

TODO:
- Kyber for PIN secret exchange
- PQC for attestations