### PR TITLE
space-opt-migration: Small fixes

### DIFF
--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -302,15 +302,13 @@ where
         response.total_credentials = Some(num_rks);
 
         // cache state for next call
-        if let Some(num_rks) = response.total_credentials {
-            if num_rks > 1 {
-                // let rp_id_hash = response.rp_id_hash.as_ref().unwrap().clone();
-                self.state.runtime.cached_rk = Some(CredentialManagementEnumerateCredentials {
-                    remaining: num_rks - 1,
-                    rp_dir: rk_dir,
-                    prev_filename: Some(first_rk.file_name().into()),
-                });
-            }
+        if num_rks > 1 {
+            // let rp_id_hash = response.rp_id_hash.as_ref().unwrap().clone();
+            self.state.runtime.cached_rk = Some(CredentialManagementEnumerateCredentials {
+                remaining: num_rks - 1,
+                rp_dir: rk_dir,
+                prev_filename: Some(first_rk.file_name().into()),
+            });
         }
 
         Ok(response)

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -307,7 +307,7 @@ where
             self.state.runtime.cached_rk = Some(CredentialManagementEnumerateCredentials {
                 remaining: num_rks - 1,
                 rp_dir: rk_dir,
-                prev_filename: Some(first_rk.file_name().into()),
+                prev_filename: first_rk.file_name().into(),
             });
         }
 
@@ -330,12 +330,10 @@ where
             prev_filename,
         } = cache;
 
-        debug_assert!(prev_filename.is_some());
-
         syscall!(self.trussed.read_dir_first_alphabetical(
             Location::Internal,
             rp_dir.clone(),
-            prev_filename
+            Some(prev_filename),
         ))
         .entry;
 
@@ -361,7 +359,7 @@ where
             self.state.runtime.cached_rk = Some(CredentialManagementEnumerateCredentials {
                 remaining: remaining - 1,
                 rp_dir,
-                prev_filename: Some(entry.file_name().into()),
+                prev_filename: entry.file_name().into(),
             });
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -211,9 +211,7 @@ pub struct CredentialManagementEnumerateRps {
 pub struct CredentialManagementEnumerateCredentials {
     pub remaining: u32,
     pub rp_dir: PathBuf,
-    /// None means that we finished iterating over the legacy credentials,
-    /// and are starting to iterate over the legacy credentials
-    pub prev_filename: Option<PathBuf>,
+    pub prev_filename: PathBuf,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -210,7 +210,6 @@ pub struct CredentialManagementEnumerateRps {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CredentialManagementEnumerateCredentials {
     pub remaining: u32,
-    pub rp_dir: PathBuf,
     pub prev_filename: PathBuf,
 }
 


### PR DESCRIPTION
Some small fixes for https://github.com/Nitrokey/fido-authenticator/pull/55.  They should eventually be squashed into the parent commit but for transparency during the review, I wanted to keep and merge them separately.

- We set `total_credentials` to `Some(num_rks)` just before accessing it, so we don’t need to go through the option.
- `prev_filename` is always set to `Some` so we can remove the `Option`.
- `rp_dir` is now always `RK_DIR` so we don’t need to cache it.