### PR TITLE
Keep old credential ID for existing credentials

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ littlefs2 = "0.5.0"
 log = "0.4.21"
 p256 = { version = "0.13.2", features = ["ecdh"] }
 rand = "0.8.4"
+rand_chacha = "0.3"
 sha2 = "0.10"
 serde_test = "1.0.176"
 trussed = { version = "0.1", features = ["virt"] }

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -174,7 +174,7 @@ where
 
                     let rp = credential.data.rp;
 
-                    response.rp_id_hash = Some(ByteArray::new(self.hash(rp.id.as_ref())));
+                    response.rp_id_hash = Some(ByteArray::new(self.hash(rp.id().as_ref())));
                     response.rp = Some(rp.into());
                 }
             }
@@ -251,7 +251,7 @@ where
 
                     let rp = credential.data.rp;
 
-                    response.rp_id_hash = Some(ByteArray::new(self.hash(rp.id.as_ref())));
+                    response.rp_id_hash = Some(ByteArray::new(self.hash(rp.id().as_ref())));
                     response.rp = Some(rp.into());
 
                     // cache state for next call
@@ -524,18 +524,22 @@ where
         // TODO: check remaining space, return KeyStoreFull
 
         // the updated user ID must match the stored user ID
-        if credential.user.id != user.id {
+        if credential.user.id() != &user.id {
             error!("updated user ID does not match original user ID");
             return Err(Error::InvalidParameter);
         }
 
         // update user name and display name unless the values are not set or empty
-        credential.data.user.name = user.name.as_ref().filter(|s| !s.is_empty()).cloned();
-        credential.data.user.display_name = user
-            .display_name
-            .as_ref()
-            .filter(|s| !s.is_empty())
-            .cloned();
+        credential
+            .data
+            .user
+            .set_name(user.name.as_ref().filter(|s| !s.is_empty()).cloned());
+        credential.data.user.set_display_name(
+            user.display_name
+                .as_ref()
+                .filter(|s| !s.is_empty())
+                .cloned(),
+        );
 
         // write updated credential
         let serialized = credential.serialize()?;

--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -530,16 +530,13 @@ where
         }
 
         // update user name and display name unless the values are not set or empty
-        credential
-            .data
-            .user
-            .set_name(user.name.as_ref().filter(|s| !s.is_empty()).cloned());
-        credential.data.user.set_display_name(
-            user.display_name
-                .as_ref()
-                .filter(|s| !s.is_empty())
-                .cloned(),
-        );
+        let credential_user = credential.data.user.as_mut();
+        credential_user.name = user.name.as_ref().filter(|s| !s.is_empty()).cloned();
+        credential_user.display_name = user
+            .display_name
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .cloned();
 
         // write updated credential
         let serialized = credential.serialize()?;


### PR DESCRIPTION
In https://github.com/Nitrokey/fido-authenticator/pull/59, we changed the format for serialized credentials to use shorter field names for the RP and user entities.  This has an unintended side effect:  For non-discoverable credentials that were generated with older crate versions, the stripped data embedded into the credential ID includes the RP and user.  If we change their serialization format, we also change these credential IDs.

We already supported deserializing both formats using a serde alias. This patch introduces helper enums that deserialize both formats using a custom Deserialize implementation and keep track of the used format. This format is then also used for serialization (using serde’s untagged mechanism that is not available for deserialization in no-std contexts).

Fixes: https://github.com/Nitrokey/fido-authenticator/issues/111

----

Notes:
- This fix means that older credentials require more size.  I think this is a reasonable trade-off.
- To simplify the code, we could also remove the `Local*` types entirely and also implement `Serialize` with a helper struct.