### PR TITLE
Remove LocalPublicKeyCredential*Entity structs

### DIFF
--- a/src/ctap2/credential_management.rs
+++ b/src/ctap2/credential_management.rs
@@ -530,16 +530,13 @@ where
         }
 
         // update user name and display name unless the values are not set or empty
-        credential
-            .data
-            .user
-            .set_name(user.name.as_ref().filter(|s| !s.is_empty()).cloned());
-        credential.data.user.set_display_name(
-            user.display_name
-                .as_ref()
-                .filter(|s| !s.is_empty())
-                .cloned(),
-        );
+        let credential_user = credential.data.user.as_mut();
+        credential_user.name = user.name.as_ref().filter(|s| !s.is_empty()).cloned();
+        credential_user.display_name = user
+            .display_name
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .cloned();
 
         // write updated credential
         let serialized = credential.serialize()?;


### PR DESCRIPTION
To simplify the Rp and User types introduced in the last commit and to reduce code duplication, this patch removes the
`LocalPublicKeyCredential*Entity` types.  Instead the Rp and User types always store a `PublicKeyCredential*Entity` together with the serialization format.

----

This reduces the overall diff from main and also significantly decreases binary size compared to the current credential-id branch (not entirely sure why).