### PR TITLE
Fix compiler warnings

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[net]
-git-fetch-with-cli = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ chunked = ["trussed-chunked"]
 
 log-all = []
 log-none = []
+log-trace = []
 log-info = []
 log-debug = []
 log-warn = []


### PR DESCRIPTION
This patch adds the missing log-trace feature and removes the deprecated and unnecessary `.cargo/config` file.