### PR TITLE
Extend integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,6 @@ features = ["dispatch"]
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "6bba8fde36d05c0227769eb63345744e87d84b2b" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "1e1ca03a3a62ea9b802f4070ea4bce002eeb4bec" }
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "4fe4e4e287dac1d92fcd4f97e8926497bfa9d7a9" }
+
+[profile.test]
+opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,10 @@ ctaphid = { version = "0.3.1", default-features = false }
 ctaphid-dispatch = "0.2"
 delog = { version = "0.1.6", features = ["std-log"] }
 env_logger = "0.11.0"
-exhaustive = "0.2.2"
 hex-literal = "0.4.1"
 hmac = "0.12.1"
 interchange = "0.3.0"
+itertools = "0.14.0"
 littlefs2 = "0.5.0"
 log = "0.4.21"
 p256 = { version = "0.13.2", features = ["ecdh"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ ctaphid = { version = "0.3.1", default-features = false }
 ctaphid-dispatch = "0.2"
 delog = { version = "0.1.6", features = ["std-log"] }
 env_logger = "0.11.0"
+exhaustive = "0.2.2"
 hex-literal = "0.4.1"
 hmac = "0.12.1"
 interchange = "0.3.0"

--- a/tests/fs/mod.rs
+++ b/tests/fs/mod.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeMap;
+
+use littlefs2_core::{path, DynFilesystem, FileType, Path};
+
+#[derive(Debug, PartialEq)]
+pub enum Entry {
+    File,
+    EmptyDir,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct Entries(pub BTreeMap<String, Entry>);
+
+impl Entries {
+    pub fn remove_standard(&mut self) {
+        self.remove_file("fido/sec/00");
+        self.remove_file("fido/x5c/00");
+        self.remove_file("trussed/dat/rng-state.bin");
+    }
+
+    pub fn remove_state(&mut self) {
+        self.remove_file("fido/dat/persistent-state.cbor");
+    }
+
+    pub fn try_remove_state(&mut self) {
+        self.0.remove("fido/dat/persistent-state.cbor");
+    }
+
+    pub fn try_remove_keys(&mut self) -> usize {
+        self.try_remove_dir("fido/sec")
+    }
+
+    pub fn try_remove_rks(&mut self) -> usize {
+        let n = self.0.len();
+        self.0.retain(|path, _| {
+            let (start, _) = path.rsplit_once('/').unwrap();
+            let start = start.rsplit_once('/').map(|(start, _)| start);
+            start != Some("fido/dat/rk")
+        });
+        n - self.0.len()
+    }
+
+    pub fn try_remove_dir(&mut self, dir: &str) -> usize {
+        let n = self.0.len();
+        self.0.retain(|path, _| {
+            let (start, _) = path.rsplit_once('/').unwrap();
+            start != dir
+        });
+        n - self.0.len()
+    }
+
+    pub fn remove_file(&mut self, path: &str) {
+        let entry = self.0.remove(path);
+        assert_eq!(entry, Some(Entry::File), "{path}");
+    }
+
+    pub fn remove_empty_dir(&mut self, path: &str) {
+        let entry = self.0.remove(path);
+        assert_eq!(entry, Some(Entry::EmptyDir), "{path}");
+    }
+
+    pub fn assert_empty(&self) {
+        assert_eq!(self.0, Default::default());
+    }
+}
+
+pub fn list_fs(fs: &dyn DynFilesystem) -> Entries {
+    fn list_dir(fs: &dyn DynFilesystem, dir: &Path, files: &mut BTreeMap<String, Entry>) -> usize {
+        fs.read_dir_and_then(dir, &mut |iter| {
+            let mut child_count = 0;
+            for entry in iter {
+                let entry = entry.unwrap();
+                if entry.file_name().as_str() == "." || entry.file_name().as_str() == ".." {
+                    continue;
+                }
+                child_count += 1;
+                match entry.file_type() {
+                    FileType::File => {
+                        files.insert(entry.path().as_str().to_owned(), Entry::File);
+                    }
+                    FileType::Dir => {
+                        let n = list_dir(fs, entry.path(), files);
+                        if n == 0 {
+                            files.insert(entry.path().as_str().to_owned(), Entry::EmptyDir);
+                        }
+                    }
+                }
+            }
+            Ok(child_count)
+        })
+        .unwrap()
+    }
+
+    let mut entries = BTreeMap::new();
+    list_dir(fs, path!(""), &mut entries);
+    Entries(entries)
+}

--- a/tests/virt/mod.rs
+++ b/tests/virt/mod.rs
@@ -85,7 +85,7 @@ where
                 let mut dispatch = Dispatch::new(rp);
                 while !poller_stop.load(Ordering::Relaxed) {
                     dispatch.poll(&mut [&mut authenticator]);
-                    thread::sleep(Duration::from_millis(10));
+                    thread::sleep(Duration::from_millis(1));
                 }
             });
 
@@ -230,7 +230,7 @@ impl HidDevice for Device<'_> {
                 };
             }
 
-            thread::sleep(Duration::from_millis(10));
+            thread::sleep(Duration::from_millis(1));
         }
     }
 }

--- a/tests/webauthn/mod.rs
+++ b/tests/webauthn/mod.rs
@@ -306,6 +306,7 @@ impl From<Value> for User {
     }
 }
 
+#[derive(Clone)]
 pub struct PubKeyCredParam {
     ty: String,
     alg: i32,
@@ -641,6 +642,7 @@ pub struct GetAssertionReply {
     pub credential: PubKeyCredDescriptor,
     pub auth_data: AuthData,
     pub signature: Vec<u8>,
+    pub number_of_credentials: Option<usize>,
 }
 
 impl From<Value> for GetAssertionReply {
@@ -650,6 +652,7 @@ impl From<Value> for GetAssertionReply {
             credential: map.remove(&0x01).unwrap().into(),
             auth_data: map.remove(&0x02).unwrap().into(),
             signature: map.remove(&0x03).unwrap().into_bytes().unwrap(),
+            number_of_credentials: map.remove(&0x05).map(|value| value.deserialized().unwrap()),
         }
     }
 }
@@ -770,6 +773,20 @@ impl CredentialData {
         message.extend_from_slice(client_data_hash);
         public_key.verify(&message, &signature).unwrap();
     }
+}
+
+pub struct GetNextAssertion;
+
+impl From<GetNextAssertion> for Value {
+    fn from(_: GetNextAssertion) -> Self {
+        Self::Null
+    }
+}
+
+impl Request for GetNextAssertion {
+    const COMMAND: u8 = 0x08;
+
+    type Reply = GetAssertionReply;
 }
 
 pub struct GetInfo;

--- a/tests/webauthn/mod.rs
+++ b/tests/webauthn/mod.rs
@@ -99,6 +99,7 @@ impl SharedSecret {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct PinToken([u8; 32]);
 
 impl PinToken {

--- a/tests/webauthn/mod.rs
+++ b/tests/webauthn/mod.rs
@@ -562,6 +562,7 @@ pub struct GetAssertion {
     client_data_hash: Vec<u8>,
     pub allow_list: Option<Vec<PubKeyCredDescriptor>>,
     pub extensions: Option<ExtensionsInput>,
+    pub options: Option<GetAssertionOptions>,
 }
 
 impl GetAssertion {
@@ -571,6 +572,7 @@ impl GetAssertion {
             client_data_hash: client_data_hash.into(),
             allow_list: None,
             extensions: None,
+            options: None,
         }
     }
 }
@@ -587,6 +589,9 @@ impl From<GetAssertion> for Value {
         if let Some(extensions) = request.extensions {
             map.push(0x04, extensions);
         }
+        if let Some(options) = request.options {
+            map.push(0x05, options);
+        }
         map.into()
     }
 }
@@ -597,6 +602,38 @@ impl Request for GetAssertion {
     type Reply = GetAssertionReply;
 }
 
+#[derive(Clone, Copy, Debug, Default, Exhaustive)]
+pub struct GetAssertionOptions {
+    pub up: Option<bool>,
+    pub uv: Option<bool>,
+}
+
+impl GetAssertionOptions {
+    pub fn up(mut self, up: bool) -> Self {
+        self.up = Some(up);
+        self
+    }
+
+    pub fn uv(mut self, uv: bool) -> Self {
+        self.uv = Some(uv);
+        self
+    }
+}
+
+impl From<GetAssertionOptions> for Value {
+    fn from(options: GetAssertionOptions) -> Value {
+        let mut map = Map::default();
+        if let Some(up) = options.up {
+            map.push("up", up);
+        }
+        if let Some(uv) = options.uv {
+            map.push("uv", uv);
+        }
+        map.into()
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub struct GetAssertionReply {
     pub credential: PubKeyCredDescriptor,
     pub auth_data: AuthData,

--- a/tests/webauthn/mod.rs
+++ b/tests/webauthn/mod.rs
@@ -193,6 +193,7 @@ impl Request for ClientPin {
 pub struct ClientPinReply {
     pub key_agreement: Option<Value>,
     pub pin_token: Option<Value>,
+    pub pin_retries: Option<u8>,
 }
 
 impl From<Value> for ClientPinReply {
@@ -201,6 +202,7 @@ impl From<Value> for ClientPinReply {
         Self {
             key_agreement: map.remove(&1),
             pin_token: map.remove(&2),
+            pin_retries: map.remove(&3).map(|value| value.deserialized().unwrap()),
         }
     }
 }

--- a/tests/webauthn/mod.rs
+++ b/tests/webauthn/mod.rs
@@ -789,6 +789,7 @@ impl Request for GetInfo {
 pub struct GetInfoReply {
     pub versions: Vec<String>,
     pub aaguid: Value,
+    pub options: Option<BTreeMap<String, Value>>,
     pub pin_protocols: Option<Vec<u8>>,
     pub attestation_formats: Option<Vec<String>>,
 }
@@ -799,6 +800,7 @@ impl From<Value> for GetInfoReply {
         Self {
             versions: map.remove(&1).unwrap().deserialized().unwrap(),
             aaguid: map.remove(&3).unwrap().deserialized().unwrap(),
+            options: map.remove(&4).map(|value| value.deserialized().unwrap()),
             pin_protocols: map.remove(&6).map(|value| value.deserialized().unwrap()),
             attestation_formats: map.remove(&0x16).map(|value| value.deserialized().unwrap()),
         }


### PR DESCRIPTION
This PR extends the integration test suite to:
- Cover more cases in makeCredential and getAssertion tests (rks, option combinations, allow lists, ...).
- Test bad getPinToken and setPin calls.
- Add tests for getPinRetries, changePin and getNextAssertion.
- Inspect the IFS after running the tests to check the directory structure and ensure that deletion works.

The new tests already caught two bugs and points us to some error codes that need to be reviewed.
- https://github.com/Nitrokey/fido-authenticator/issues/119
- https://github.com/Nitrokey/fido-authenticator/issues/120