### PR TITLE
hmac-secret: Forbid up=false

### DIFF
--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -1448,6 +1448,10 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
                 .transpose()?
                 .unwrap_or(PinProtocolVersion::V1);
 
+            if !get_assertion_state.up_performed {
+                return Err(Error::UnsupportedOption);
+            }
+
             // We derive credRandom as an hmac of the existing private key.
             // UV is used as input data since credRandom should depend UV
             // i.e. credRandom = HMAC(private_key, uv)

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -774,6 +774,11 @@ impl TestGetAssertion {
         if !self.rk && !self.allow_list {
             return Some(0x2e);
         }
+        if let Some(options) = self.options {
+            if options.up == Some(false) && self.ga_hmac_secret {
+                return Some(0x2b);
+            }
+        }
         None
     }
 }


### PR DESCRIPTION
This PR extends the test suite with tests for the hmac-secret extension and fixes its implementation to reject requests with up set to false.

Fixes: https://github.com/Nitrokey/fido-authenticator/issues/19