### PR TITLE
make_credential: Support non-discoverable credentials without PIN

### DIFF
--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -75,6 +75,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
         };
         options.large_blobs = Some(self.config.supports_large_blobs());
         options.pin_uv_auth_token = Some(true);
+        options.make_cred_uv_not_rqd = Some(true);
 
         let mut transports = Vec::new();
         if self.config.nfc_transport {
@@ -1409,8 +1410,8 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
                     return Err(Error::PinAuthInvalid);
                 }
             } else {
-                // 6. pinAuth not present + clientPin set --> error PinRequired
-                if self.state.persistent.pin_is_set() {
+                // 6. pinAuth not present + clientPin set + rk = true --> error PinRequired
+                if options.as_ref().and_then(|options| options.rk) == Some(true) {
                     return Err(Error::PinRequired);
                 }
             }

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -1383,9 +1383,12 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
         }
 
         // 4. If authenticator is protected by som form of user verification, do it
-        //
-        // TODO: Should we should fail if `uv` is passed?
-        // Current thinking: no
+
+        // Reject uv = true as we do not support built-in user verification
+        if pin_auth.is_none() && options.as_ref().and_then(|options| options.uv) == Some(true) {
+            return Err(Error::InvalidOption);
+        }
+
         if self.state.persistent.pin_is_set() {
             // let mut uv_performed = false;
             if let Some(pin_auth) = pin_auth {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -602,17 +602,15 @@ impl TestMakeCredential {
             if !matches!(self.pin_auth, PinAuth::PinToken(_)) && options.uv == Some(true) {
                 return Some(0x2c);
             }
-        }
-        match &self.pin_auth {
-            PinAuth::PinToken(
-                RequestPinToken::InvalidPermissions | RequestPinToken::InvalidRpId,
-            ) => {
-                return Some(0x33);
-            }
-            PinAuth::PinNoToken => {
+            if matches!(self.pin_auth, PinAuth::PinNoToken) && options.rk == Some(true) {
                 return Some(0x36);
             }
-            _ => {}
+        }
+        if let PinAuth::PinToken(
+            RequestPinToken::InvalidPermissions | RequestPinToken::InvalidRpId,
+        ) = &self.pin_auth
+        {
+            return Some(0x33);
         }
         if !self.valid_pub_key_alg {
             return Some(0x26);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -599,6 +599,9 @@ impl TestMakeCredential {
             if options.up.is_some() {
                 return Some(0x2c);
             }
+            if !matches!(self.pin_auth, PinAuth::PinToken(_)) && options.uv == Some(true) {
+                return Some(0x2c);
+            }
         }
         match &self.pin_auth {
             PinAuth::PinToken(
@@ -610,12 +613,6 @@ impl TestMakeCredential {
                 return Some(0x36);
             }
             _ => {}
-        }
-        if let Some(options) = self.options {
-            // TODO: review if uv should be always rejected due to the lack of built-in uv
-            if !matches!(self.pin_auth, PinAuth::PinToken(_)) && options.uv == Some(true) {
-                return Some(0x2c);
-            }
         }
         if !self.valid_pub_key_alg {
             return Some(0x26);


### PR DESCRIPTION
Currently, we always require the PIN to be used for make_credential operations if it is set.  This PR implements the makeCredUvNotRqd option that allows non-discoverable credentials to be created without using the PIN according to § 6.1.2 Step 6 of the specification, see:

https://fidoalliance.org/specs/fido-v2.1-rd-20201208/fido-client-to-authenticator-protocol-v2.1-rd-20201208.html#sctn-makeCred-authnr-alg
https://fidoalliance.org/specs/fido-v2.1-rd-20201208/fido-client-to-authenticator-protocol-v2.1-rd-20201208.html#getinfo-makecreduvnotrqd

It also fixes the error code for cases where uv is set to true to follow the specification more closely.

Fixes: https://github.com/Nitrokey/fido-authenticator/issues/34