### PR TITLE
clientPin: Support getRetries without PIN protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ required-features = ["dispatch"]
 
 [dependencies]
 cbor-smol = { version = "0.5" }
-ctap-types = { version = "0.3.1", features = ["get-info-full", "large-blobs", "third-party-payment"] }
+ctap-types = { version = "0.4", features = ["get-info-full", "large-blobs", "third-party-payment"] }
 cosey = "0.3"
 delog = "0.1.0"
 heapless = "0.7"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-ctap-types = { version = "0.3.0", features = ["arbitrary"] }
+ctap-types = { version = "0.4", features = ["arbitrary"] }
 libfuzzer-sys = "0.4"
 trussed = { version = "0.1", features = ["clients-1", "certificate-client", "crypto-client", "filesystem-client", "management-client", "aes256-cbc", "ed255", "p256", "sha256"] }
 trussed-staging = { version = "0.3.0", features = ["chunked", "hkdf", "virt", "fs-info"] }


### PR DESCRIPTION
This fixes compatibility with CTAP 2.1.

Fixes: https://github.com/Nitrokey/fido-authenticator/issues/118